### PR TITLE
Update release steps

### DIFF
--- a/release-process.md
+++ b/release-process.md
@@ -8,6 +8,7 @@ title: The Rust Release Process &middot; The Rust Programming Language
 The Rust release process is mostly in my head right now, so I took notes on how
 it went this time (1.3.0).
 
+
 ## Promote beta to stable (T-3 days, Monday)
 
 Promote beta to stable.  This is local, in your Rust repo, assuming you have
@@ -31,45 +32,8 @@ will upload docs to the s3 bin under `doc/$version`, but *not* `doc/stable`, and
 will not upload the bins anywhere, instead leaving them staged in the
 `tmp/dist/packaging-stable/final` subdirectory of the buildbot master.
 
-## Promote master to beta (T-2 days, Tuesday)
 
-Branch a cargo commit for the Rust beta:
-
-```sh
-$ cd cargo
-$ git fetch rust-lang
-$ git push rust-lang rust-lang/master:rust-1.14.0
-```
-
-Promote master to beta as with yesterday:
-
-```sh
-$ git fetch rust-lang
-$ git push rust-lang rust-lang/master:beta -f
-```
-
-Like yesterday, promote any nightly-only `*_cross_targets` arrays to also be
-included on the beta channel.
-
-Send a commit to the freshly created beta branch of rust-lang/rust
-which updates src/stage0.txt to bootstrap from this new stable
-compiler. The format is "X.Y.Z-YYYY-MM-DD", and the date is the
-archive date of the new stable build, which can be found in the
-manifests sitting in the
-tmp/packaging-stable/final/channel-rust-stable.toml file on the build
-master. Do not update the Cargo version in this file.
-
-Manually start the `beta-dist-rustc-trigger`. The beta build will use
-the rustc binaries that already exist in the archives (only the
-combined 'rust' package hasn't been uploaded). The beta will deploy
-automatically.
-
-Make and submit a patch against master that bumps the version number in
-`mk/main.mk`.
-
-## Prerelease testing (T-1 day, Wednesday)
-
-Write a new blog post and update rust-www. Submit PRs for tomorrow.
+## Archive upload and prerelease testing (T-2 day, Wednesday)
 
 Now upload the bins to an s3 staging directory for testing as follows.
 This happens on the buildmaster under the rustbuild user.
@@ -105,9 +69,54 @@ or rustup.sh with
 curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --spec=stable-2015-09-17
 ```
 
-Send a PR to the master branch to start bootstrapping from the new
-beta produced yesterday by modifying src/stage0.txt. Also update with
-the Cargo version selected yesterday as well.
+
+## Promote master to beta (T-2 days, Tuesday)
+
+Branch a cargo commit for the Rust beta:
+
+```sh
+$ cd cargo
+$ git fetch rust-lang
+$ git push rust-lang rust-lang/master:rust-1.14.0
+```
+
+Promote master to beta as with yesterday:
+
+```sh
+$ git fetch rust-lang
+$ git push rust-lang rust-lang/master:beta -f
+```
+
+Like yesterday, promote any nightly-only `*_cross_targets` arrays to also be
+included on the beta channel.
+
+Send a commit to the freshly created beta branch of rust-lang/rust
+which:
+
+- updates src/stage0.txt to bootstrap from this new stable
+  compiler. The format is "X.Y.Z-YYYY-MM-DD", and the date is the
+  archive date of the new stable build, which can be found in the
+  manifests sitting in the
+  tmp/packaging-stable/final/channel-rust-stable.toml file on the
+  build master. Do not update the Cargo version in this file.
+- Also update src/ci/run.sh to pass "--release-channel=beta".
+
+Manually start the `beta-dist-rustc-trigger`. The beta build will use
+the rustc binaries that already exist in the archives (only the
+combined 'rust' package hasn't been uploaded). The beta will deploy
+automatically.
+
+
+# Master bootstrap update (T-1 day, Wednesday)
+
+Write a new blog post and update rust-www. Submit PRs for tomorrow.
+
+Send a PR to the master branch to:
+
+- modify src/stage0.txt to bootstrap from yesterday's beta
+- modify src/stage0.txt to bootstrap from yesterday's beta's cargo
+- modify mk/main.mk with the new version number
+
 
 ## Release day (Thursday)
 


### PR DESCRIPTION
The big change here is that the prerelease testing step move forward a day to be in front of producing the beta. That's because the beta needs the new stable rust from the archives to bootstrap.

r? @alexcrichton 