### PR TITLE
ides.md: add information about GNOME Builder

### DIFF
--- a/ides.md
+++ b/ides.md
@@ -59,6 +59,7 @@ Available IDE plugins:
 * [Eclipse](https://github.com/RustDT/RustDT)
 * [Visual Studio](https://github.com/PistonDevelopers/VisualRust)
 * [IntelliJ IDEA](https://intellij-rust.github.io)
+* [GNOME Builder](https://wiki.gnome.org/Apps/Builder)
 
 Editor plugins:
 
@@ -147,6 +148,18 @@ Repository: [https://github.com/PistonDevelopers/VisualRust](https://github.com/
 Issues: [https://github.com/PistonDevelopers/VisualRust/issues](https://github.com/PistonDevelopers/VisualRust/issues)
 
 Contact: [vosen@vosen.pl](https://github.com/vosen/)
+
+**GNOME Builder**
+
+Installation instructions: [https://wiki.gnome.org/Apps/Builder/Downloads](https://wiki.gnome.org/Apps/Builder/Downloads)
+
+Download: [https://wiki.gnome.org/Apps/Builder/Downloads](https://wiki.gnome.org/Apps/Builder/Downloads)
+
+Repository: [https://git.gnome.org/browse/gnome-builder](https://git.gnome.org/browse/gnome-builder)
+
+Issues: [https://bugzilla.gnome.org](https://bugzilla.gnome.org/buglist.cgi?quicksearch=product:gnome-builder)
+
+Contact: [Christian Hergert](https://github.com/chergert/)
 
 ### Editor Plugins
 


### PR DESCRIPTION
The GNOME Builder IDE has had support for Rust and the Rust Language Server
since 3.22. It natively supports various rls and cargo features such as:

 - Support for the cargo build system
 - Auto-completion using racer via rls
 - As-you-type diagnostics
 - Rename symbol
 - Jump to Symbol
 - Symbol Tree

And upcoming 3.24 features include

 - Support for rustup toolchain management
 - Documentation support