### PR TITLE
add description of how to edit teams, apply aturon's nits

### DIFF
--- a/rfc-merge-procedure.md
+++ b/rfc-merge-procedure.md
@@ -4,7 +4,7 @@ title: RFC Merge Procedure
 ---
 
 Once an RFC has been accepted (i.e., the final comment period is
-complete), it must be merged. Right now this is a manual process,
+complete, and no major issues were raised), it must be merged. Right now this is a manual process,
 though just about anyone can do it (if you're not a subteam member,
 though, you'll have to open a PR rather than merge the RFC
 manually). Here is the complete set of steps to merge an RFC -- in
@@ -38,7 +38,6 @@ XXX --- list all the "unresolved questions" found in the RFC
 Add the following labels to the issue:
 
 - `B-rfc-approved`
-- `B-unstable`
 - the approriate `T-XXX` label
 
 (If you don't have permissions to do so, leave a note cc'ing the

--- a/rustc-team-maintenance.md
+++ b/rustc-team-maintenance.md
@@ -1,6 +1,14 @@
 The roster of the Rust subteams is always in flux. From time to time, new people are added, but also people sometimes opt to into "alumni status", meaning that they are not currently an active part of the decision-making process. Unfortunately, whenever a new person is added or someone goes into alumni status, there are a number of disparate places that need to be updated. This page aims to document that list. If you have any questions, or need someone with more privileges to make a change for you, a good place to ask is #rust-infra (or possibly #rust-internals).
 
-Places that will need to be updated:
+### R+ rights
+
+If just giving r+ rights, the following places need to be modified:
+
+- bors
+
+### Full feam membership
+
+To make a full team member, the following places need to be modified:
 
 - the [team roster page](https://github.com/rust-lang/rust-www/blob/master/team.md)
 - the rust-lang/TEAM and rust-lang-nursery/TEAM team on github

--- a/rustc-team-maintenance.md
+++ b/rustc-team-maintenance.md
@@ -1,0 +1,12 @@
+The roster of the Rust subteams is always in flux. From time to time, new people are added, but also people sometimes opt to into "alumni status", meaning that they are not currently an active part of the decision-making process. Unfortunately, whenever a new person is added or someone goes into alumni status, there are a number of disparate places that need to be updated. This page aims to document that list. If you have any questions, or need someone with more privileges to make a change for you, a good place to ask is #rust-infra (or possibly #rust-internals).
+
+Places that will need to be updated:
+
+- the [team roster page](https://github.com/rust-lang/rust-www/blob/master/team.md)
+- the rust-lang/TEAM and rust-lang-nursery/TEAM team on github
+- rfcbot has a separate list of people on a team that is maintained in a database
+    - you can ping dikaiosune on IRC, or else prepare a migration
+    - [here is an example migration that was adding Carol to the core team](https://github.com/dikaiosune/rust-dashboard/tree/master/migrations/20170222224139_carols10cents_tools_team)
+    - to remove someone, simply reverse the up/down steps
+- the easydns service has an e-mail alias (`compiler-team@rust-lang.org`) that needs to be updated
+    - best here is to ask around in #rust-infra

--- a/rustc-team-maintenance.md
+++ b/rustc-team-maintenance.md
@@ -11,7 +11,7 @@ If just giving r+ rights, the following places need to be modified:
 To make a full team member, the following places need to be modified:
 
 - the [team roster page](https://github.com/rust-lang/rust-www/blob/master/team.md)
-- the rust-lang/TEAM and rust-lang-nursery/TEAM team on github
+- the [rust-lang/TEAM](https://github.com/orgs/rust-lang/teams) and (in some cases) [rust-lang-nursery/TEAM](https://github.com/orgs/rust-lang-nursery/teams) teams on github must be updated
 - rfcbot has a separate list of people on a team that is maintained in a database
     - you can ping dikaiosune on IRC, or else prepare a migration
     - [here is an example migration that was adding Carol to the tools team](https://github.com/dikaiosune/rust-dashboard/tree/master/migrations/20170222224139_carols10cents_tools_team)

--- a/rustc-team-maintenance.md
+++ b/rustc-team-maintenance.md
@@ -4,7 +4,7 @@ The roster of the Rust subteams is always in flux. From time to time, new people
 
 If just giving r+ rights, the following places need to be modified:
 
-- bors
+- the [homu template on rust-central-station](https://github.com/alexcrichton/rust-central-station/blob/master/homu.toml.template)
 
 ### Full feam membership
 

--- a/rustc-team-maintenance.md
+++ b/rustc-team-maintenance.md
@@ -10,3 +10,4 @@ Places that will need to be updated:
     - to remove someone, simply reverse the up/down steps
 - the easydns service has an e-mail alias (`compiler-team@rust-lang.org`) that needs to be updated
     - best here is to ask around in #rust-infra
+- the [internals discussion board has per-team groups](https://internals.rust-lang.org/admin/groups/custom)

--- a/rustc-team-maintenance.md
+++ b/rustc-team-maintenance.md
@@ -6,7 +6,7 @@ Places that will need to be updated:
 - the rust-lang/TEAM and rust-lang-nursery/TEAM team on github
 - rfcbot has a separate list of people on a team that is maintained in a database
     - you can ping dikaiosune on IRC, or else prepare a migration
-    - [here is an example migration that was adding Carol to the core team](https://github.com/dikaiosune/rust-dashboard/tree/master/migrations/20170222224139_carols10cents_tools_team)
+    - [here is an example migration that was adding Carol to the tools team](https://github.com/dikaiosune/rust-dashboard/tree/master/migrations/20170222224139_carols10cents_tools_team)
     - to remove someone, simply reverse the up/down steps
 - the easydns service has an e-mail alias (`compiler-team@rust-lang.org`) that needs to be updated
     - best here is to ask around in #rust-infra


### PR DESCRIPTION
This is mostly a PR that starts a list with the steps to add/remove someone from a rust-lang team.

cc @alexcrichton -- see anything missing? Any tips on what needs to happen for r+?