### PR TITLE
Add link to a documentation page for Homu syntax.

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,3 +50,5 @@ PRs against [rust-lang-nursery/rust-forge].
 * [Team maintenance](rustc-team-maintenance.html)
 
 * [PR Triage Procedure](pr-triage-procedure.html)
+
+* [Homu/Bors Syntax](https://buildbot2.rust-lang.org/homu/)


### PR DESCRIPTION
Not quite sure if we want this; but seems good. A dedicated page would probably be better but I don't quite have time for that right now, and this seems like a good start (and more likely to be up to date).

r? @aturon