### PR TITLE
Link to newer Rust plugin for Visual Studio Code

### DIFF
--- a/ides.md
+++ b/ides.md
@@ -69,8 +69,7 @@ Editor plugins:
 * [Vim](https://github.com/rust-lang/rust.vim)
 * [Sublime Text](https://packagecontrol.io/packages/Rust)
 * [Atom](https://atom.io/packages/language-rust)
-* [Visual Studio 
-](https://marketplace.visualstudio.com/items?itemName=kalitaalexey.vscode-rust)
+* [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=kalitaalexey.vscode-rust)
 
 Code completion is available via
 [Racer](https://github.com/phildawes/racer).  See

--- a/ides.md
+++ b/ides.md
@@ -69,7 +69,8 @@ Editor plugins:
 * [Vim](https://github.com/rust-lang/rust.vim)
 * [Sublime Text](https://packagecontrol.io/packages/Rust)
 * [Atom](https://atom.io/packages/language-rust)
-* [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=saviorisdead.RustyCode)
+* [Visual Studio 
+](https://marketplace.visualstudio.com/items?itemName=kalitaalexey.vscode-rust)
 
 Code completion is available via
 [Racer](https://github.com/phildawes/racer).  See


### PR DESCRIPTION
The last commit to https://github.com/saviorisdead/RustyCode was on October 14, 2016 - The readme for https://github.com/editor-rs/vscode-rust states that it's a fork with "additional features and many bugfixes".

Submitting this PR because someone warned me RustyCode was deprecated just after I installed it because of this page :)