### PR TITLE
Fix broken links to homu

### DIFF
--- a/infrastructure.md
+++ b/infrastructure.md
@@ -17,9 +17,9 @@ Most services in the Rust Infrastructure are deployed via [rust-central-station]
 
 ## Homu
 
-[Homu](http://github.com/barosl/homu/) is a bot ([bot user account](https://github.com/bors)) which manages pull requests. Approved pull requests are placed in [a queue](http://buildbot.rust-lang.org/homu/queue/rust) from which tests are run.
+[Homu](http://github.com/servo/homu/) is a bot ([bot user account](https://github.com/bors)) which manages pull requests. Approved pull requests are placed in [a queue](http://buildbot2.rust-lang.org/homu/queue/rust) from which tests are run.
 
-Documentation on homu commands can be found [here](http://buildbot.rust-lang.org/homu/). If you wish to use homu for your own repository, try out [homu.io](http://homu.io/).
+Documentation on homu commands can be found [here](http://buildbot2.rust-lang.org/homu/). If you wish to use a similar bot for your own repository, try out [bors-ng](https://bors.tech/).
 
 Please contact [Alex Crichton](https://github.com/alexcrichton) if something goes wrong with the bot.
 


### PR DESCRIPTION
This also swaps out the now-defunct homu.io for bors.tech. If you'd rather link to something else, or would rather recommend running your own instance of homu, then that's fine too.