### PR TITLE
Add "Update rendered link" to RFC merge procedure

### DIFF
--- a/rfc-merge-procedure.md
+++ b/rfc-merge-procedure.md
@@ -65,5 +65,12 @@ flavor (and change the team):
 To track further discussion, subscribe to the tracking issue here: rust-lang/rust#41517
 ```
 
+### Step 4: Update the rendered link
+
+Update the rendered link in the first post of the PR to the permanent home under
+`https://github.com/rust-lang/rfcs/blob/master/text/`.
+
+(This way future visitors can open it easily after the PR branch is deleted.)
+
 ### That's it, you're done!
 


### PR DESCRIPTION
Since there have been a few followup posts requesting this, such as https://github.com/rust-lang/rfcs/pull/2052#issuecomment-333876009