### PR TITLE
Remove mention to IDEs

### DIFF
--- a/index.md
+++ b/index.md
@@ -24,9 +24,6 @@ PRs against [rust-lang-nursery/rust-forge].
 
 * [Friend of the Tree archives](fott.html).
 
-* [IDE initiative](ides.html). Ongoing work into improving IDE support
-  for Rust.
-
 * [Bibliography](bibliography.html). Research papers and other links
   to projects that influenced Rust. Papers about Rust.
 


### PR DESCRIPTION
Despite the live website showing an old page, the current repository does not include the page linked here.