### PR TITLE
Move Solaris to Tier 2

### DIFF
--- a/platform-support.md
+++ b/platform-support.md
@@ -82,9 +82,11 @@ these platforms are required to have each of the following:
 | `powerpc64le-unknown-linux-gnu`   |  ✓  |  ✓  |  ✓  | PPC64LE Linux                |
 | `s390x-unknown-linux-gnu`         |  ✓  |  ✓  |  ✓  | S390x Linux                  |
 | `sparc64-unknown-linux-gnu`       |  ✓  |     |     | SPARC Linux                  |
+| `sparcv9-sun-solaris`             |  ✓  |     |     | SPARC Solaris 10/11, illumos |
 | `wasm32-unknown-emscripten`       |  ✓  |     |     | WebAssembly via Emscripten   |
 | `x86_64-apple-ios`                |  ✓  |     |     | 64-bit x86 iOS               |
 | `x86_64-rumprun-netbsd`           |  ✓  |     |     | 64-bit NetBSD Rump Kernel    |
+| `x86_64-sun-solaris`              |  ✓  |     |     | 64-bit Solaris 10/11, illumos|
 | `x86_64-unknown-freebsd`          |  ✓  |  ✓  |  ✓  | 64-bit FreeBSD               |
 | `x86_64-unknown-fuchsia`          |  ✓  |     |     | 64-bit Fuchsia               |
 | `x86_64-unknown-linux-musl`       |  ✓  |     |     | 64-bit Linux with MUSL       |
@@ -109,13 +111,11 @@ Official builds are not available.
 | `mipsel-unknown-linux-uclibc`   |  ✓  |     |     | MIPS (LE) Linux with uClibc                              |
 | `msp430-none-elf`               |  *  |     |     | 16-bit MSP430 microcontrollers                           |
 | `sparc64-unknown-netbsd`        |  ✓  |  ✓  |     | NetBSD/sparc64                                           |
-| `sparcv9-sun-solaris`           |  ✓  |  ✓  |  ✓  | Solaris/sparc 10/11, illumos/sparc                       |
 | `thumbv6m-none-eabi`            |  *  |     |     | Bare Cortex-M0, M0+, M1                                  |
 | `thumbv7em-none-eabi`           |  *  |     |     | Bare Cortex-M4, M7                                       |
 | `thumbv7em-none-eabihf`         |  *  |     |     | Bare Cortex-M4F, M7F, FPU, hardfloat                     |
 | `thumbv7m-none-eabi`            |  *  |     |     | Bare Cortex-M3                                           |
 | `x86_64-pc-windows-msvc` (XP)   |  ✓  |     |     | Windows XP support                                       |
-| `x86_64-sun-solaris`            |  ✓  |  ✓  |  ✓  | 64-bit Solaris 10/11, illumos                            |
 | `x86_64-unknown-bitrig`         |  ✓  |  ✓  |     | 64-bit Bitrig                                            |
 | `x86_64-unknown-dragonfly`      |  ✓  |  ✓  |     | 64-bit DragonFlyBSD                                      |
 | `x86_64-unknown-haiku`          |  ✓  |     |     | 64-bit Haiku                                             |


### PR DESCRIPTION
With the upcoming stable release std is officially built for and tested on Solaris.
rustc and cargo are not Tier 2 yet.