### PR TITLE
Change `it's` to `its`

### DIFF
--- a/x-py.md
+++ b/x-py.md
@@ -257,7 +257,7 @@ documentation you want.
 
 ### Document internal rustc items
 
-By default `rustc` does not build the compiler for it's internal items.
+By default `rustc` does not build the compiler for its internal items.
 Mostly because this is useless for the average user. However, you might need to
 have it available so you can understand the types. Here's how you can compile it
 yourself. From the top level directory where `x.py` is located run:


### PR DESCRIPTION
`it's` is a contraction of `it has` or `it is`. In some cases the
contraction for `it has` does come after `for`, but here it seems clear
that this is intended to be the possessive for `it`.

I chose not to rewrap the text of the rest of the paragraph for a typo-only change.