### PR TITLE
Update stale reference to config.toml.example location

### DIFF
--- a/x-py.md
+++ b/x-py.md
@@ -257,7 +257,7 @@ documentation you want.
 
 ### Document internal rustc items
 
-By default `rustc` does not build the compiler for its internal items.
+By default `rustc` does not build the compiler docs for its internal items.
 Mostly because this is useless for the average user. However, you might need to
 have it available so you can understand the types. Here's how you can compile it
 yourself. From the top level directory where `x.py` is located run:

--- a/x-py.md
+++ b/x-py.md
@@ -263,7 +263,7 @@ have it available so you can understand the types. Here's how you can compile it
 yourself. From the top level directory where `x.py` is located run:
 
 ```bash
-cp src/bootstrap/config.toml.example config.toml
+cp config.toml.example config.toml
 ```
 
 Next open up `config.toml` and make sure these two lines are set to true:


### PR DESCRIPTION
In 1126a85e87629f7ec37fc6c4fde43419f4b9947f, rust-lang/rust moved
`config.toml.example` from `src/bootstrap/` to the project root.

Instructions in rust-lang/rust were updated, but this instance was not.