### PR TITLE
feat(content): move other installation methods doc from website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,18 @@
 name: The Rust Programming Language
+stable: "1.30.1"
+stable_date: "2018-11-08"
+stable_blog: "https://blog.rust-lang.org/2018/11/08/Rust-1.30.1.html"
+stable_full_version: "rustc 1.30.1 (1433507eb 2018-11-07)"
+beta: "1.31"
+beta_date: "2018-12-06"
+nightly: "1.32"
+channels:
+  - name: "stable"
+    vers: "1.30.1"
+    package: "1.30.1"
+  - name: "beta"
+    vers: "1.31"
+    package: "beta"
+  - name: "nightly"
+    vers: "1.32"
+    package: "nightly"

--- a/_data/platforms.yml
+++ b/_data/platforms.yml
@@ -1,0 +1,97 @@
+rustup:
+  -
+    - aarch64-unknown-linux-gnu
+    - arm-unknown-linux-gnueabi
+    - arm-unknown-linux-gnueabihf
+    - i686-apple-darwin
+    - i686-pc-windows-gnu
+    - i686-pc-windows-msvc
+    - i686-unknown-linux-gnu
+    - mips-unknown-linux-gnu
+    - mipsel-unknown-linux-gnu
+    - mips64-unknown-linux-gnuabi64
+    - mips64el-unknown-linux-gnuabi64
+  -
+    - powerpc-unknown-linux-gnu
+    - powerpc64-unknown-linux-gnu
+    - powerpc64le-unknown-linux-gnu
+    - x86_64-apple-darwin
+    - x86_64-pc-windows-gnu
+    - x86_64-pc-windows-msvc
+    - x86_64-unknown-freebsd
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-netbsd
+
+stable:
+  -
+    - aarch64-unknown-linux-gnu
+    - arm-unknown-linux-gnueabi
+    - arm-unknown-linux-gnueabihf
+    - i686-apple-darwin
+    - i686-pc-windows-gnu
+    - i686-pc-windows-msvc
+    - i686-unknown-linux-gnu
+    - mips-unknown-linux-gnu
+    - mipsel-unknown-linux-gnu
+    - mips64-unknown-linux-gnuabi64
+    - mips64el-unknown-linux-gnuabi64
+  -
+    - powerpc-unknown-linux-gnu
+    - powerpc64-unknown-linux-gnu
+    - powerpc64le-unknown-linux-gnu
+    - s390x-unknown-linux-gnu
+    - x86_64-apple-darwin
+    - x86_64-pc-windows-gnu
+    - x86_64-pc-windows-msvc
+    - x86_64-unknown-freebsd
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-netbsd
+
+beta:
+  -
+    - aarch64-unknown-linux-gnu
+    - arm-unknown-linux-gnueabi
+    - arm-unknown-linux-gnueabihf
+    - i686-apple-darwin
+    - i686-pc-windows-gnu
+    - i686-pc-windows-msvc
+    - i686-unknown-linux-gnu
+    - mips-unknown-linux-gnu
+    - mipsel-unknown-linux-gnu
+    - mips64-unknown-linux-gnuabi64
+  -
+    - powerpc-unknown-linux-gnu
+    - powerpc64-unknown-linux-gnu
+    - powerpc64le-unknown-linux-gnu
+    - s390x-unknown-linux-gnu
+    - x86_64-apple-darwin
+    - x86_64-pc-windows-gnu
+    - x86_64-pc-windows-msvc
+    - x86_64-unknown-freebsd
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-netbsd
+
+nightly:
+  -
+    - aarch64-unknown-linux-gnu
+    - arm-unknown-linux-gnueabi
+    - arm-unknown-linux-gnueabihf
+    - i686-apple-darwin
+    - i686-pc-windows-gnu
+    - i686-pc-windows-msvc
+    - i686-unknown-linux-gnu
+    - mips-unknown-linux-gnu
+    - mipsel-unknown-linux-gnu
+    - mips64-unknown-linux-gnuabi64
+    - mips64el-unknown-linux-gnuabi64
+  -
+    - powerpc-unknown-linux-gnu
+    - powerpc64-unknown-linux-gnu
+    - powerpc64le-unknown-linux-gnu
+    - s390x-unknown-linux-gnu
+    - x86_64-apple-darwin
+    - x86_64-pc-windows-gnu
+    - x86_64-pc-windows-msvc
+    - x86_64-unknown-freebsd
+    - x86_64-unknown-linux-gnu
+    - x86_64-unknown-netbsd

--- a/css/style.css
+++ b/css/style.css
@@ -501,3 +501,25 @@ ul.laundry-list {
     margin: 0 0 0 2rem;
     padding: 0;
 }
+
+.installer-table {
+  display: flex;
+  margin: 2rem;
+  justify-content: space-around;
+}
+
+.installer-table > div > div > span {
+  float: left;
+  margin-left: 1em;
+  margin-right: 1em;
+}
+
+.rustup-init-table {
+  display: flex;
+  margin: 2rem;
+  justify-content: space-around;
+}
+
+.rustup-init-table > div > a {
+  display: block;
+}

--- a/index.md
+++ b/index.md
@@ -50,6 +50,7 @@ PRs against [rust-lang-nursery/rust-forge].
 * [Friend of the Tree archives](fott.html).
 * [Bibliography](bibliography.html). Research papers and other links to projects that influenced Rust. Papers about Rust.
 * [Cross compilation resources](cross-compilation/index.html)
+* [Other Rust Installation Methods](other-installation-methods.html)
 
 <script>
 

--- a/other-installation-methods.md
+++ b/other-installation-methods.md
@@ -1,0 +1,187 @@
+---
+layout: default
+title: Other Installation Methods &middot; The Rust Programming Language
+---
+
+# Other Rust Installation Methods
+
+- [Which installer should you use?](#which)
+- [Other ways to install `rustup`](#more-rustup)
+- [Standalone installers](#standalone)
+- [Source code](#source)
+
+## Which installer should you use?
+<span id="which"></span>
+
+Rust runs on many platforms, and there are many ways to install Rust. If you
+want to install Rust in the most straightforward, recommended way, then follow
+the instructions on the main [installation page].
+
+That page describes installation via [`rustup`], a tool that manages multiple
+Rust toolchains in a consistent way across all platforms Rust supports. Why
+might one _not_ want to install using those instructions?
+
+- Offline installation. `rustup` downloads components from the internet on
+  demand. If you need to install Rust without access to the internet, `rustup`
+  is not suitable.
+- Preference for the system package manager. On Linux in particular, but also on
+  macOS with [Homebrew], and Windows with [Chocolatey], developers sometimes
+  prefer to install Rust with their platform's package manager.
+- Preference against `curl | sh`. On Unix, we usually install `rustup` by
+  running a shell script via `curl`. Some have concerns about the security of
+  this arrangement and would prefer to download and run the installer
+  themselves.
+- Validating signatures. Although `rustup` performs its downloads over HTTPS,
+  the only way to verify the signatures of Rust installers today is to do so
+  manually with the standalone installers.
+- GUI installation and integration with "Add/Remove Programs" on
+  Windows. `rustup` runs in the console and does not register its installation
+  like typical Windows programs. If you prefer a more typical GUI installation
+  on Windows there are standalone `.msi` installers. In the future
+  `rustup` will also have a GUI installer on Windows.
+
+Rust's platform support is defined in [three tiers], which correspond closely
+with the installation methods available: in general, the Rust project provides
+binary builds for all tier 1 and tier 2 platforms, and they are all installable
+via `rustup`. Some tier 2 platforms though have only the standard library
+available, not the compiler itself; that is, they are cross-compilation targets
+only; Rust code can run on those platforms, but they do not run the compiler
+itself. Such targets can be installed with the `rustup target add` command.
+
+## Other ways to install `rustup`
+<span id="rustup"></span>
+
+The way to install `rustup` differs by platform:
+
+* On Unix, run `curl https://sh.rustup.rs -sSf | sh` in your
+  shell. This downloads and runs [`rustup-init.sh`], which in turn
+  downloads and runs the correct version of the `rustup-init`
+  executable for your platform.
+* On Windows, download and run [`rustup-init.exe`].
+
+`rustup-init` can be configured interactively, and all options can additionally
+be controlled by command-line arguments, which can be passed through the shell
+script. Pass `--help` to `rustup-init` as follows to display the arguments
+`rustup-init` accepts:
+
+```
+curl https://sh.rustup.rs -sSf | sh -s -- --help
+```
+
+If you prefer not to use the shell script, you may directly download
+`rustup-init` for the platform of your choice:
+
+<div class="rustup-init-table">
+  {% for column in site.data.platforms.rustup %}
+  <div>
+    {% for target in column %}
+    {% if target contains 'windows' %}
+    <a href="https://static.rust-lang.org/rustup/dist/{{ target }}/rustup-init.exe">
+      {{ target }}
+    </a>
+    {% else %}
+    <a href="https://static.rust-lang.org/rustup/dist/{{ target }}/rustup-init">
+      {{ target }}
+    </a>
+    {% endif %}
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+
+## Standalone installers
+<span id="standalone"></span>
+
+The official Rust standalone installers contain a single release of Rust, and
+are suitable for offline installation. They come in three forms: tarballs
+(extension `.tar.gz`), that work in any Unix-like environment, Windows
+installers (`.msi`), and Mac installers (`.pkg`). These installers come with
+`rustc`, `cargo`, `rustdoc`, the standard library, and the standard
+documentation, but do not provide access to additional cross-targets like
+`rustup` does.
+
+The most common reasons to use these are:
+
+- Offline installation
+- Prefering a more platform-integrated, graphical installer on Windows
+
+Each of these binaries is signed with the [Rust signing key], which is
+[available on keybase.io], by the Rust build infrastructure, with
+[GPG]. In the tables below, the `.asc` files are the signatures.
+
+Past releases can be found in [the archives].
+
+{% for channel in site.channels %}
+
+### {{ channel.name | capitalize }} ({{ channel.vers }})
+<span id="{{ channel.name }}"></span>
+
+<div class="installer-table {{ channel.name }}">
+  {% for column in site.data.platforms[channel.name] %}
+  <div>
+    {% for target in column %}
+    <div>
+      <span>{{ target }}</span>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.tar.gz.asc">.asc</a>
+    </div>
+    {% if target contains 'windows' %}
+    <div>
+      <span>{{ target }}</span>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.msi">.msi</a>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.msi.asc">.asc</a>
+    </div>
+    {% elsif target contains 'darwin' %}
+    <div>
+      <span>{{ target }}</span>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.pkg">.pkg</a>
+      <a href="https://static.rust-lang.org/dist/rust-{{ channel.package }}-{{ target }}.pkg.asc">.asc</a>
+    </div>
+    {% endif %}
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+
+{% endfor %}
+
+## Source code
+<span id="source"></span>
+
+<div class="installer-table">
+  <div>
+    <div>
+      <span>Stable</span>
+      <a href="https://static.rust-lang.org/dist/rustc-{{ site.stable }}-src.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rustc-{{ site.stable }}-src.tar.gz.asc">.asc</a>
+    </div>
+  </div>
+  <div>
+    <div>
+      <span>Beta</span>
+      <a href="https://static.rust-lang.org/dist/rustc-beta-src.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rustc-beta-src.gz.asc">.asc</a>
+    </div>
+  </div>
+  <div>
+    <div>
+      <span>Nightly</span>
+      <a href="https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz">.tar.gz</a>
+      <a href="https://static.rust-lang.org/dist/rustc-nightly-src.tar.gz.asc">.asc</a>
+    </div>
+  </div>
+</div>
+
+[installation page]: install.html
+[`rustup`]: https://github.com/rust-lang-nursery/rustup.rs
+[other-rustup]: https://github.com/rust-lang-nursery/rustup.rs#other-installation-methods
+[`rustup-init.exe`]: https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe
+[`rustup-init.sh`]: https://static.rust-lang.org/rustup/rustup-init.sh
+[Homebrew]: http://brew.sh/
+[Chocolatey]: http://chocolatey.org/
+[three tiers]: https://forge.rust-lang.org/platform-support.html
+[Rust signing key]: https://static.rust-lang.org/rust-key.gpg.ascii
+[GPG]: https://gnupg.org/
+[available on keybase.io]: https://keybase.io/rust
+[the archives]: https://static.rust-lang.org/dist/index.html
+


### PR DESCRIPTION
![screenshot_2018-11-15 other installation methods the rust programming language 1](https://user-images.githubusercontent.com/1163554/48561619-53133c80-e8be-11e8-847a-710d274631cd.png)
