### PR TITLE
Add documentation about new `concerns_label` field for major-change

### DIFF
--- a/src/triagebot/major-changes.md
+++ b/src/triagebot/major-changes.md
@@ -32,6 +32,10 @@ second_label = "final-comment-period"
 # Typically this is used to track what needs to be discussed at a meeting.
 meeting_label = "to-announce"
 
+# Label that indicates there are active concerns on the MCP
+# Typically tracked by `@rustbot concern`
+concerns_label = "has-concerns"
+
 # When this label is added to an issue, that triggers acceptance of the proposal
 # which sends an update to Zulip.
 # Defaults to "major-change-accepted".


### PR DESCRIPTION
cf. https://github.com/rust-lang/triagebot/pull/2051

r? @Kobzol 

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/triagebot/major-changes.md)