### PR TITLE
rdg: use repo name

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -61,7 +61,7 @@
     - [Triage and Prioritization](./compiler/prioritization.md)
     - [Working Areas](./compiler/working-areas.md)
     - [Operations](./compiler/operations.md)
-- [Rustc Dev Guide](./wg-rustc-dev-guide/README.md)
+- [rustc-dev-guide](./wg-rustc-dev-guide/README.md)
 - [crates.io](./crates-io/README.md)
     - [Crate removal](./crates-io/crate-removal.md)
     - [Database maintenance](./crates-io/db-maintenance.md)

--- a/src/wg-rustc-dev-guide/README.md
+++ b/src/wg-rustc-dev-guide/README.md
@@ -1,4 +1,4 @@
-# Rustc Dev Guide
+# rustc-dev-guide
 
 The rustc-dev-guide working group is responsible for maintaining the rustc-dev-guide (located at 
 [rust-lang/rustc-dev-guide](https://github.com/rust-lang/rustc-dev-guide)). This includes things such


### PR DESCRIPTION
The complete name is Rust Compiler Development Guide, which is a mouthful. So, use the repo name, because Rustc Dev Guide would be a third form.

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/SUMMARY.md)