### PR TITLE
Increase max width of content to 1000px

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,6 +10,7 @@ command = "./build.bash"
 
 [output.html]
 additional-js = ["js/moment.min.js", "js/index.js"]
+additional-css = ["css/style.css"]
 no-section-label = true
 git-repository-url = "https://github.com/rust-lang/rust-forge"
 edit-url-template = "https://github.com/rust-lang/rust-forge/edit/master/{path}"

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,3 @@
+:root {
+    --content-max-width: 1000px;
+}


### PR DESCRIPTION
It seems a bit silly to me to be reading the pages with a super narrow and compressed page content width on a FullHD monitor, while half of the page is just background. This PR increases tha max width of the page content from 750 to 1000px.

Feel free to close if you like the narrow pages :)