### PR TITLE
Mention we don't accept typofixes on internal docs and tests

### DIFF
--- a/src/how-to-start-contributing.md
+++ b/src/how-to-start-contributing.md
@@ -30,7 +30,7 @@ expert time", but we do not feel that way. Contributors are important to us.
 ## How to start contributing?
 
 The Rust project is quite large and it can be difficult to know which parts of the project need
-help, or are a good starting place for beginners. Here is a (non-exhaustive) list of 
+help, or are a good starting place for beginners. Here is a (non-exhaustive) list of
 `rust-lang` projects that could serve as starting places for you to contribute. Some of them
 have contributor guides and issues that are marked as needing help or being good first issues.
 
@@ -38,19 +38,19 @@ have contributor guides and issues that are marked as needing help or being good
 |------------------------------------|-------------------------------------------------|---------------------------------------|-----------------------------------------|
 | [Compiler][rustc-repo]             | [rustc-dev-guide][rustc-guide]                  | [Good first issues][rustc-issues]     | Rust compiler and associated tooling    |
 | [Standard library][std-repo]       | [std-dev-guide][std-guide]                      |                                       | Rust standard library                   |
-| [Rustdoc][rustdoc-repo]            | [Rustdoc overview][rustdoc-guide]               |                                       | Rust documentation generator            | 
-| [Cargo][cargo-repo]                | [Cargo Contributor Guide][cargo-guide]          | [Good first issues][cargo-issues]     | Rust package manager and build system   | 
+| [Rustdoc][rustdoc-repo]            | [Rustdoc overview][rustdoc-guide]               |                                       | Rust documentation generator            |
+| [Cargo][cargo-repo]                | [Cargo Contributor Guide][cargo-guide]          | [Good first issues][cargo-issues]     | Rust package manager and build system   |
 | [Clippy][clippy-repo]              | [Clippy Contributor Guide][clippy-guide]        | [Good first issues][clippy-issues]    | Rust linter                             |
 | [Rustfmt][rustfmt-repo]            | [Rustfmt Contributing Guide][rustfmt-guide]     | [Good first issues][rustfmt-issues]   | Rust formatter                          |
 | [Rust analyzer][analyzer-repo]     | [Contributing Quick Start][analyzer-guide]      | [Good first issues][analyzer-issues]  | Rust compiler frontend and LSP for IDEs |
 | [Miri][miri-repo]                  | [Miri Contribution Guide][miri-guide]           | [Good first issues][miri-issues]      | Rust interpreter and UB detector        |
 | [Rustup][rustup-repo]              | [Rustup Developer Guide][rustup-guide]          | [Help wanted][rustup-issues]          | Rust toolchain installer                |
-| [crates.io][crates-io-repo]        | [crates.io Contribution guide][crates-io-guide] | [Issue tracker][crates-io-issues]     | Rust package registry                   | 
-| [Bors][bors-repo]                  | [bors Development guide][bors-guide]            | [Help wanted][bors-issues]            | Rust CI merge bot                       | 
-| [rustc-perf][rustc-perf-repo]      |                                                 | [Help wanted][rustc-perf-issues]      | Rust compiler benchmark suite           | 
-| [Triagebot][triagebot-repo]        |                                                 | [Good first issues][triagebot-issues] | Rust automation bot                     | 
-| [Rust playground][playground-repo] |                                                 | [Help wanted][playground-issues]      | Rust online playground                  | 
-| [Rustlings][rustlings-repo]        | [Rustlings Contribution Guide][rustlings-guide] | [Issue tracker][rustlings-issues]     | Rust exercises                          | 
+| [crates.io][crates-io-repo]        | [crates.io Contribution guide][crates-io-guide] | [Issue tracker][crates-io-issues]     | Rust package registry                   |
+| [Bors][bors-repo]                  | [bors Development guide][bors-guide]            | [Help wanted][bors-issues]            | Rust CI merge bot                       |
+| [rustc-perf][rustc-perf-repo]      |                                                 | [Help wanted][rustc-perf-issues]      | Rust compiler benchmark suite           |
+| [Triagebot][triagebot-repo]        |                                                 | [Good first issues][triagebot-issues] | Rust automation bot                     |
+| [Rust playground][playground-repo] |                                                 | [Help wanted][playground-issues]      | Rust online playground                  |
+| [Rustlings][rustlings-repo]        | [Rustlings Contribution Guide][rustlings-guide] | [Issue tracker][rustlings-issues]     | Rust exercises                          |
 | [MdBook][mdbook-repo]              | [MdBook Contribution Guide][mdbook-guide]       | [Good first issues][mdbook-issues]    | Book generator written in Rust          |
 
 [rustc-repo]: https://github.com/rust-lang/rust
@@ -110,15 +110,24 @@ There are various ways in which you can contribute to Rust projects:
   you can help improve our GitHub CI workflows, automation Python scripts or contribute to web
   frontends with HTML/CSS/JS (e.g. [Rustdoc][rustdoc-ui] or [Benchmark suite website][rustc-perf-ui]).
   Play to your strengths!
+
 - Improving documentation is possibly one of the easiest starting points for contributions.
   Did you find a typo, something that was unclear, or do you miss some useful information on this
   page, elsewhere in the Forge or in some other Rust (user-facing) documentation? Great, then send
   a pull request and you'll become a contributor! :)
+
+  Please notice that at this time **we don't accept typography/spellcheck fixes to internal
+  documentation** (usually not worth the churn or the review time) **or in our testsuite** (they
+  could inadvertently cause code regressions)
+
 - Improving tests is also very valuable, as there is never enough of them. This can include also
   documenting existing tests or writing tests for already fixed issues that lack a proper test.
+
 - You can also help with improving issue trackers of our repositories, by helping with [triaging issues][issue-triage]
   or by reproducing old issues to find out whether they are still valid or not.
+
 - Or, if you like programming language discussions, you could participate in our [RFC process](https://github.com/rust-lang/rfcs).
+
 - You can also answer questions to help other Rust users, in the _Get Help!_ channels on the [Rust Discord
   server][rust-discord], on [users.rust-lang.org][users] (URLO), or on [StackOverflow][so].
 


### PR DESCRIPTION
We routinely receive typofixes PRs (some are genuine, some are spam). We decline those that are on internal documentation (see [rust#144863](https://togithub.com/rust-lang/rust/pull/144763), [rust#143729](https://togithub.com/rust-lang/rust/pull/143729), [rust#143315](https://togithub.com/rust-lang/rust/pull/143315) etc.) or to our rust testsuite because they *could* cause regressions, see [rust#136384](https://togithub.com/rust-lang/rust/pull/136384) or [rust#129867](https://github.com/rust-lang/rust/pull/129867) etc.).

I'd like to add clear wording about this in our "How to start contributing guide", I *think* this is not mentioned anywhere. This is not to not keep out spam (for that we have other tools) but rather for guiding contributions better.

If this is approved, I would like to add the same wording also to the rustc-dev guide (for example [here](https://rustc-dev-guide.rust-lang.org/#other-ways-to-contribute))

Feel free to improve my wording!

Opinions?

thanks

Note: the added newlines in the list make the list a bit easier on the eyes
<details><summary>Details</summary>
<p>

<img width="1056" height="592" alt="screenshot-20250805-115243" src="https://github.com/user-attachments/assets/cb44718a-ed56-4950-9ca4-8138fabf0991" />


</p>
</details> 


[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/how-to-start-contributing.md)