### PR TITLE
only link to easy issues in good first issues in rustc

### DIFF
--- a/src/how-to-start-contributing.md
+++ b/src/how-to-start-contributing.md
@@ -52,7 +52,7 @@ have contributor guides and issues that are marked as needing help or being good
 | [MdBook][mdbook-repo]              | [MdBook Contribution Guide][mdbook-guide]       | [Good first issues][mdbook-issues]    | Book generator written in Rust          |
 
 [rustc-repo]: https://github.com/rust-lang/rust
-[rustc-issues]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted+no%3Aassignee
+[rustc-issues]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-easy+no%3Aassignee
 [rustc-guide]: https://rustc-dev-guide.rust-lang.org
 [std-repo]: https://github.com/rust-lang/rust/tree/master/library
 [std-guide]: https://github.com/rust-lang/std-dev-guide


### PR DESCRIPTION
Right now, good first issues link to issues with the E-help-wanted label, even though this shows hard issues too (E-hard).  I replaced help wanted label with E-easy label.

[Rendered](https://github.com/rust-lang/rust-forge/blob/eaa63ecd840948bd7a32fd714d9209e0ceedeb52/src/how-to-start-contributing.md)