### PR TITLE
Add documentation for triagebot `[review-changes-since]`

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -39,6 +39,7 @@
     - [Pinging](./triagebot/pinging.md)
     - [Rendered link](./triagebot/rendered-link.md)
     - [Requesting Prioritization](./triagebot/requesting-prioritization.md)
+    - [Review Changes Since](./triagebot/review-changes-since.md)
     - [Review Changes Requested](./triagebot/review-submitted.md)
     - [Review Requested](./triagebot/review-requested.md)
     - [Rustc Commit Tracking](./triagebot/rustc-commit-list.md)

--- a/src/triagebot/review-changes-since.md
+++ b/src/triagebot/review-changes-since.md
@@ -1,0 +1,19 @@
+# Review Changes Since
+
+This feature will automatically adjust the body of a GitHub review to include a link to view the changes that happened since the review.
+
+## Usage
+
+When creating a pull request review, the bot will automatically append at the end of the review body a link to view the changes that happened since the review.
+
+## Configuration
+
+This feature is enabled on a repository by having a `[review-changes-since]` table in `triagebot.toml`:
+
+```toml
+[review-changes-since]
+```
+
+## Implementation
+
+See [`src/handlers/review_changes_since.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/review_changes_since.rs).


### PR DESCRIPTION
This PR adds documentation for the newly added triagebot `[review-changes-since]` feature.

Related to https://github.com/rust-lang/triagebot/pull/2163
r? @Kobzol

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/triagebot/review-changes-since.md)