### PR TITLE
Auto-assign internal-sites for general changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -14,12 +14,12 @@ warn_non_default_branch = true
 [assign.adhoc_groups]
 fallback = [
     "@Mark-Simulacrum",
-    "@ehuss",
+    "internal-sites",
 ]
 
 [assign.owners]
-"/blacksmith" = ["@ehuss"]
-"/js" = ["@ehuss"]
+"/blacksmith" = ["internal-sites"]
+"/js" = ["internal-sites"]
 "/src/community" = ["community"]
 "/src/compiler" = ["compiler"]
 "/src/crates-io" = ["crates-io"]


### PR DESCRIPTION
This updates the auto-assignment to include the new internal-sites team.

cc @rust-lang/internal-sites 

r? internal-sites
