### PR TITLE
Remove the state-of-rust redirect

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -36,7 +36,6 @@ smart-punctuation = true
 "rustc-diagnostic-code.html" = "/compiler/diagnostic-codes.html"
 "rustc-team-maintenance.html" = "/infra/team-maintenance.html"
 "stabilization-guide.html" = "https://rustc-dev-guide.rust-lang.org/stabilization_guide.html"
-"state-of-rust.html" = "https://github.com/rust-lang/rust/projects/8"
 "test-suite.html" = "https://rustc-dev-guide.rust-lang.org/tests/intro.html"
 "toolstate.html" = "/infra/toolstate.html"
 "triage-procedure.html" = "/release/triage-procedure.html"


### PR DESCRIPTION
This page was removed in
https://github.com/rust-lang/rust-forge/pull/221 to point to a GitHub project. However, that project seems to have been deleted some time ago, so the redirect goes nowhere. I don't think there is anything really to point this, and I think it has been long enough that it doesn't matter.