### PR TITLE
Update blacksmith to Rust 2024

### DIFF
--- a/blacksmith/Cargo.toml
+++ b/blacksmith/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook-blacksmith"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "A mdbook preprocessor for generating dynamic content for Rust Forge."
 publish = false
 

--- a/blacksmith/rustfmt.toml
+++ b/blacksmith/rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2024"


### PR DESCRIPTION
This updates blacksmith to the 2024 edition.