### PR TITLE
Allow seconding instantly

### DIFF
--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -16,6 +16,7 @@ are suitable for each method of making a proposal - see below):
     accepts a proposal subject to a ten-day waiting period for other team members to raise any
     concerns.
   - Seconding can only be used to approve a MCP.
+  - You can "unsecond" by removing the `seconded` label on the MCP.
 - FCP
   - A Final Comment Period is started by a T-compiler member. it's a tool to get concrete consensus
     from the team. This requires sign-off from the compiler FCP reviewers (the [`compiler-fcp`


### PR DESCRIPTION
We already have the 10 day waiting period, so waiting for discussion to conclude is superfluous (and not done in practice).

Discussed in [the `t-compiler/contrib-private` Zulip stream](https://rust-lang.zulipchat.com/#narrow/channel/244344-t-compiler.2Fcontrib-private/topic/vibe-check.3A.20needs.20mcp.3F).

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/compiler/proposals-and-stabilization.md)