### PR TITLE
Fix typos

### DIFF
--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -12,7 +12,7 @@ are suitable for each method of making a proposal - see below):
   - A proposal is r+'d when it is approved to be merged.
   - r+ can only be used to approve a PR.
 - Seconding
-  - A proposal is second'ed when a team member formally endorses the proposal. Seconding tentatively
+  - A proposal is seconded when a team member formally endorses the proposal. Seconding tentatively
     accepts a proposal subject to a ten-day waiting period for other team members to raise any
     concerns.
   - Seconding can only be used to approve a MCP.

--- a/src/compiler/reviews.md
+++ b/src/compiler/reviews.md
@@ -232,7 +232,7 @@ gets in the way of refactorings, and no hard stability guarantees are promised.
 
 ### The PR is very large and complicated
 Reviewers are **not** expected to stomach PRs that are very large and complicated. It is expected
-from contributors to split their work to make a review feasable, for example a series of more
+from contributors to split their work to make a review feasible, for example a series of more
 digestible PRs which are individually more logically self-contained. In general, before submitting
 large impact changes, it is expected the contributor to have discussed the design previously with
 the relevant team(s) so it is contributor's duty to reference such discussions.

--- a/src/infra/docs/dev-desktop.md
+++ b/src/infra/docs/dev-desktop.md
@@ -9,7 +9,7 @@ free access to high-powered cloud compute. They are part of the
 | `dev-desktop-eu-1` | `aarch64`    | Yes          | Germany        |
 | `dev-desktop-us-1` | `aarch64`    | Yes          | N. Virgina, US |
 
-#### Decomissioned Machines
+#### Decommissioned Machines
 
 Previously, these machines were also available:
 
@@ -18,7 +18,7 @@ Previously, these machines were also available:
 | `dev-desktop-eu-2` | `amd64`      | No           | Netherlands    |
 | `dev-desktop-us-2` | `amd64`      | No           | Washington, US |
 
-They are currently being [decomissioned](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Shutting.20down.20dev-desktop-*-2.20instances).
+They are currently being [decommissioned](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Shutting.20down.20dev-desktop-*-2.20instances).
 
 ## How to apply to the program
 

--- a/src/infra/docs/dns.md
+++ b/src/infra/docs/dns.md
@@ -196,7 +196,7 @@ and take inspiration from the other domain names).
 
 If you notice some of the records are referring to HTTP redirect services
 provided by the current registrar then those will have to wait until the domain
-has been transferred. Once the transfer occured, add a new [domain
+has been transferred. Once the transfer occurred, add a new [domain
 redirect][redirects-file] on Terraform. This has to be done after the transfer
 to be able to request the TLS certificate for the HTTPS redirect.
 

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -9,7 +9,7 @@ status, there are a number of disparate places that need to be updated.
 # Team repo
 
 Membership of teams is primarily driven by the config files in the
-[rust-lang/team repo][team repo]. See the README of that respository for the
+[rust-lang/team repo][team repo]. See the README of that repository for the
 systems integrated with it.
 
 # Rules for changes to team repo

--- a/src/lang/rfc-merge-procedure.md
+++ b/src/lang/rfc-merge-procedure.md
@@ -35,7 +35,7 @@ Add the following labels to the issue:
 
 - `B-rfc-approved`
 - `C-tracking-issue`
-- the approriate `T-XXX` label
+- the appropriate `T-XXX` label
 
 (If you don't have permissions to do so, leave a note cc'ing the appropriate
 team and asking them to do so.)

--- a/src/lang/triage-meeting-procedure.md
+++ b/src/lang/triage-meeting-procedure.md
@@ -34,7 +34,7 @@ To execute this meeting you:
 * For each item, click in and try to add a few notes as to the main topic
     * look for things where there isn't much discussion needed, or just reminders
     * these can be handled quickly in the meeting, or perhaps not at all
-    * items that require more discussion will need time alotted for them
+    * items that require more discussion will need time allotted for them
 
 [Current Meeting]: https://paper.dropbox.com/doc/T-Lang-Meeting-Current-meeting--AmyXFNnryXTNzBsSWjbdJcVSAg-nRfrSxCbfeo9q7fEYogZQ
 

--- a/src/libs/maintaining-std.md
+++ b/src/libs/maintaining-std.md
@@ -156,7 +156,7 @@ This kind of breakage can be ok, but a [`crater`] run should estimate the scope.
 
 ### Could an implementation use existing functionality?
 
-Types like `String` are implemented in terms of `Vec<u8>` and can use methods on `str` through deref coersion. `Vec<T>` can use methods on `[T]` through deref coersion. When possible, methods on a wrapping type like `String` should defer to methods that already exist on their underlying storage or deref target.
+Types like `String` are implemented in terms of `Vec<u8>` and can use methods on `str` through deref coercion. `Vec<T>` can use methods on `[T]` through deref coercion. When possible, methods on a wrapping type like `String` should defer to methods that already exist on their underlying storage or deref target.
 
 ### Are there `#[fundamental]` items involved?
 

--- a/src/platforms/blogs.md
+++ b/src/platforms/blogs.md
@@ -107,7 +107,7 @@ This approval should evaluate:
 * Is the tone and content of the post appropriate for the official venue?
   * For example, we should avoid negative commentary about other ecosystems/languages.
 * Is it clear on whose behalf the post is written?
-  * This may not just be the by-line, but also the langauge used. If the post
+  * This may not just be the by-line, but also the language used. If the post
     takes official positions on behalf of the Rust Project as a whole, please
     make sure at least one member of the leadership council signs off on it. If the
     post is taking positions on behalf of a team, then that team should be in

--- a/src/release/issue-triaging.md
+++ b/src/release/issue-triaging.md
@@ -175,7 +175,7 @@ Anything related to the compiler implementation, such as diagnostics and ICEs.
 
 ##### T-opsem
 * Changes to [the nomicon](https://doc.rust-lang.org/nomicon/)
-* Changes to the semantics of the abstract machine, such as the sematics of atomics.
+* Changes to the semantics of the abstract machine, such as the semantics of atomics.
 * Changes to the docs of unsafe pointer functions
 * Changes to the docs of `core::ptr`
 

--- a/src/release/process.md
+++ b/src/release/process.md
@@ -6,7 +6,7 @@ Here's how Rust is currently released:
 
 Steps of the release process that require interacting with our production
 environment are executed through the `start-release.py` script. The script
-requires you to install programs and configure your local environmet, and it
+requires you to install programs and configure your local environment, and it
 will guide you through the setup.
 
 The first time you run the script (or when the pre-requisites change), you will

--- a/src/release/release-notes.md
+++ b/src/release/release-notes.md
@@ -48,7 +48,7 @@ Stabilized APIs and Const Stabilized APIs should both be formatted roughly as fo
 
 ```md
 - [`std::ptr::null_mut`](https://doc.rust-lang.org/std/ptr/fn.null_mut.html)
-<!-- for trait implemenations: -->
+<!-- for trait implementations: -->
 - [`impl<T: Clone, const N: usize> From<&[T; N]> for Vec<T>`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#impl-From%3C%26%5BT;+N%5D%3E-for-Vec%3CT,+Global%3E)
 ```
 
@@ -60,8 +60,8 @@ Note that:
   unsigned integers) to avoid too much text.
 * link fragments can be long and hard to predict, so it is often better to copy and paste the url than write it manually
   (if the item doesn't appear in stable docs, you can copy it from nightly and edit the url).
-* if the only thing being stablized is trait implementations (and not the corrosponding trait),
-  all impls are listed with links to the corrosponding impl blocks.
+* if the only thing being stabilized is trait implementations (and not the corresponding trait),
+  all impls are listed with links to the corresponding impl blocks.
 ## Release team: Step 3: Confirm all issues/PRs needing relnotes are labeled `relnotes`
 
 This steps should happen in the first 3 weeks of the beta period (earlier is


### PR DESCRIPTION
By running the `typos` CLI tool, as well as a manual fix for a typo found in https://github.com/rust-lang/rust-forge/pull/967#discussion_r2469270924.

r? nnethercote

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/release/release-notes.md)