### PR TITLE
Rename incorrect `seconded` label

### DIFF
--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -16,7 +16,7 @@ are suitable for each method of making a proposal - see below):
     accepts a proposal subject to a ten-day waiting period for other team members to raise any
     concerns.
   - Seconding can only be used to approve a MCP.
-  - You can "unsecond" by removing the `seconded` label on the MCP.
+  - You can "unsecond" by removing the `final-comment-period` label on the MCP.
 - FCP
   - A Final Comment Period is started by a T-compiler member. it's a tool to get concrete consensus
     from the team. This requires sign-off from the compiler FCP reviewers (the [`compiler-fcp`


### PR DESCRIPTION
See https://github.com/rust-lang/rust-forge/pull/967#discussion_r2469384493.

r? apiraino

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/compiler/proposals-and-stabilization.md)