### PR TITLE
Don't create msi links for windows gnullvm targets

### DIFF
--- a/blacksmith/src/lib.rs
+++ b/blacksmith/src/lib.rs
@@ -312,7 +312,7 @@ impl Blacksmith {
             writeln!(buffer, "---------|--------").unwrap();
 
             for name in platforms {
-                let extensions: &[&str] = if name.contains("windows") {
+                let extensions: &[&str] = if name.contains("windows") && !name.contains("gnullvm") {
                     &["msi", "tar.gz"]
                 } else if name.contains("darwin") {
                     &["pkg", "tar.gz"]


### PR DESCRIPTION
Since msi installers for windows gnullvm targets are not being published, it should not be part of the documentation.

Ideally it would be better if there would be msi installers for these targets in my opinion though.