### PR TITLE
Document that Zulip is the primary communication channel of the Project

### DIFF
--- a/src/platforms/zulip.md
+++ b/src/platforms/zulip.md
@@ -1,7 +1,6 @@
 # Zulip
 
-[Rust's Zulip](https://rust-lang.zulipchat.com) is the primary communication channel of the Rust Project.
-It is used by most teams, notably the compiler, language, and library teams, along with their working groups.
+[Rust's Zulip](https://rust-lang.zulipchat.com) is a chat platform used by members of Rust teams to discuss the development of Rust.
 
 Zulip can be an unintuitive platform to get started with. To get started, take a
 look at the [getting started


### PR DESCRIPTION
And that we require all Project members to have a Zulip ID.


[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/platforms/zulip.md)