### PR TITLE
Enable sidebar navigation folding

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -11,6 +11,10 @@ command = "./build.bash"
 [build]
 extra-watch-dirs = ["blacksmith/src"]
 
+[output.html.fold]
+enable = true
+level = 0
+
 [output.html]
 additional-js = ["js/moment.min.js", "js/index.js"]
 additional-css = ["css/style.css"]


### PR DESCRIPTION
This enables the sidebar navigation folding feature in mdbook (https://rust-lang.github.io/mdBook/format/configuration/renderers.html#outputhtmlfold) which collapses the sidebar by default. You can look at https://rustc-dev-guide.rust-lang.org/ as an example of folded chapters.

The main issue is that the sidebar has become quite long over time, and it can make it a little harder to see the big picture. Particularly the triagebot and infrastructure sections have a large number of sub-chapters which can overwhelm the navigation.

I don't love this 100% because it can make it a little harder for certain navigation use-cases. For example, I can't use my browser's search functionality and enter "zulip" to find the zulip-related chapters. I now have to use mdbook's search bar, and mdbook's search output isn't particularly great (especially the ranking). But overall I think this is a net win.

r? @rust-lang/internal-sites 