### PR TITLE
don't invalidate cloudfront distribution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,13 +13,13 @@ jobs:
       RUN_BLACKSMITH: 1
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install mdbook
         run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz
       - name: Build book
         run: ./mdbook build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./book/html
 
@@ -39,10 +39,3 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::890664054962:role/forge-rust-lang-org-ci
-          aws-region: us-east-1
-      - name: Invalidate CloudFront cache
-        run: aws cloudfront create-invalidation --distribution-id E12A3GKHZSREHP --paths "/*"


### PR DESCRIPTION
I'm deleting the rust-forge cloudfront distribution (we use github pages now), so we shouldn't invalidate it anymore from CI.

Related to https://github.com/rust-lang/simpleinfra/issues/731