### PR TITLE
Fix formatting in notification group page

### DIFF
--- a/src/compiler/notification-groups.md
+++ b/src/compiler/notification-groups.md
@@ -1,5 +1,5 @@
 # Notification groups
-The compiler team has a number of notification groups that used to ping people and draw their
+The compiler team has a number of notification groups that are used to ping people and draw their
 attention to issues. Notification groups are setup so that anyone can join them if they want.
 
 Please keep in mind that only members of a Rust project GitHub team can use these notification
@@ -11,18 +11,18 @@ from the compiler team:
 
 * File a tracking issue in the [rust-lang/compiler-team] repository to collect your progress.
 * Create a PR against the [rust-lang/team] repository adding the notification
-  group [(Example PR)](https://github.com/rust-lang/team/pull/347)
+  group ([Example PR](https://github.com/rust-lang/team/pull/347))
 * Configure the [rust-lang/rust] repository to accept triagebot commands
-  for this group. [(Example PR.)))](https://github.com/rust-lang/rust/pull/72706)
+  for this group. ([Example PR)](https://github.com/rust-lang/rust/pull/72706)
 * Create a PR for the rustc-dev-guide amending [the notification group
   section](https://rustc-dev-guide.rust-lang.org/notification-groups/about.html)
   to mention your group.
 * Create a sample PR for the [rust-lang/team] repository showing how one can add
   oneself. This will be referenced by your blog post to show people how to
-  join. [(Example PR)](https://github.com/rust-lang/team/pull/140)
+  join. ([Example PR](https://github.com/rust-lang/team/pull/140))
 * Write an announcement blog post for Inside Rust and open a PR against
-  [blog.rust-lang.org](https://github.com/rust-lang/blog.rust-lang.org).
-  [(Example PR)](https://github.com/rust-lang/blog.rust-lang.org/pull/615)
+  [blog.rust-lang.org](https://github.com/rust-lang/blog.rust-lang.org)
+  ([Example PR](https://github.com/rust-lang/blog.rust-lang.org/pull/615))
 
 [rust-lang/compiler-team]: https://github.com/rust-lang/compiler-team
 [rust-lang/team]: https://github.com/rust-lang/team


### PR DESCRIPTION
Just something I noticed while casually reading this page

(See [current rendering](https://forge.rust-lang.org/compiler/notification-groups.html) before this patch, there's something off with the parenthesis)

thanks

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/compiler/notification-groups.md)