### PR TITLE
disable create-missing option

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -10,6 +10,7 @@ command = "./build.bash"
 
 [build]
 extra-watch-dirs = ["blacksmith/src"]
+create-missing = false
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
Imo this feature is confusing, and it would allow us to catch things like https://github.com/rust-lang/rust-forge/pull/1035 in CI.

It's easy to create the file yourself.

## What does this feature do

In `SUMMARY.md`, if you link to a file that doesn't exist, `mdbook build` will create that file.

## Alternative approach to fix this issue

* Leave the option enabled.
* After running `mdbook build` in CI, check if the git diff is clean to make sure that `mdbook build` didn't create files.

- [x] Rebase on top of https://github.com/rust-lang/rust-forge/pull/1035 once it's merged, to fix CI