### PR TITLE
Zizmor fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build book
         run: ./mdbook build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5
         with:
           path: ./book/html
 
@@ -52,4 +52,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout repository without persisting credentials to reduce attack surface
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
       - name: Install mdbook

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,30 +6,44 @@ on:
     branches:
       - master
 
+# Limit concurrent workflow runs to prevent resource conflicts and ensure clean deployments
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+# Default permissions for all jobs - minimal access
+permissions: {}
+
 jobs:
   build:
+    name: Build site
     env:
       MDBOOK_VERSION: 0.5.1
       RUN_BLACKSMITH: 1
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      # Checkout repository without persisting credentials to reduce attack surface
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          persist-credentials: false
       - name: Install mdbook
         run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz
       - name: Build book
         run: ./mdbook build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: ./book/html
 
   deploy:
+    name: Deploy to GitHub Pages
     if: github.repository_owner == 'rust-lang'
     needs: build
 
+    # Required permissions for GitHub Pages deployment
     permissions:
-      pages: write
-      id-token: write
+      pages: write  # Required to deploy to GitHub Pages
+      id-token: write  # Required for OIDC authentication with GitHub Pages service
 
     environment:
       name: github-pages
@@ -38,4 +52,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       RUN_BLACKSMITH: 1
     steps:
       # Checkout repository without persisting credentials to reduce attack surface
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
       - name: Install mdbook

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,15 @@ name: Test
 on:
   pull_request:
 
+# Cancel in-progress runs for the same PR to save resources
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Minimal permissions for testing
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test
@@ -11,7 +20,10 @@ jobs:
       MDBOOK_OUTPUT__LINKCHECK__WARNING_POLICY: error
       RUN_BLACKSMITH: 1
     steps:
-      - uses: actions/checkout@v4
+      # Checkout repository without persisting credentials to reduce attack surface
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          persist-credentials: false
       - name: Install mdbook
         run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz
       - name: Install mdbook-linkcheck2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout repository without persisting credentials to reduce attack surface
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: Security Audit with zizmor
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/workflows/**'
+
+# Cancel in-progress runs for the same PR to save resources
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+# Minimal permissions for auditing
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Run zizmor security audit
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository without persisting credentials to reduce attack surface
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: cargo install zizmor
+
+      - name: Run zizmor audit
+        run: zizmor --persona pedantic --min-severity low .github/workflows

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,7 +30,10 @@ jobs:
           persist-credentials: false
 
       - name: Install zizmor
-        run: cargo install zizmor
+        run: |
+          curl -sSL https://github.com/woodruffw/zizmor/releases/download/v1.24.1/zizmor-x86_64-unknown-linux-gnu.tar.gz | tar -xz
+          chmod +x zizmor
+          sudo mv zizmor /usr/local/bin/
 
       - name: Run zizmor audit
         run: zizmor --persona pedantic --min-severity low .github/workflows


### PR DESCRIPTION
Fix Zizmor security findings in GitHub Actions workflows

deploy.yml changes:
- Pin actions to commit hashes 
- Add persist-credentials: false to checkout
- Add explicit permissions blocks with comments:
  - workflow: permissions: {}
  - deploy job: pages: write, id-token: write
- Add job names 
- Add concurrency limits (high severity):
  - group: pages, cancel-in-progress: false

test.yml changes:
- Pin actions/checkout@v4
- Add persist-credentials: false
- Add permissions: contents: read 
- Add concurrency limits with cancel-in-progress: true 

Add Zizmor security audit workflow to prevent Zizmor issues from happening again.

Security impact: Eliminates risks of:
- Compromised action tags executing malicious code
- Leaked GitHub tokens from credential persistence
- Overly broad workflow permissions enabling privilege escalation
- Concurrent workflow runs are causing race conditions or resource exhaustion.
- CI/CD regressions