### PR TITLE
Fix source tarball validation instructions

### DIFF
--- a/src/infra/other-installation-methods.md
+++ b/src/infra/other-installation-methods.md
@@ -114,10 +114,17 @@ wget https://ci-artifacts.rust-lang.org/rustc-builds/${TAG}/rustc-nightly-src.ta
 # Download a source tarball for a stable release
 # wget https://static.rust-lang.org/dist/rustc-${TAG}-src.tar.xz
 
-# Decompress the tarballs and check if they're the same
+# Decompress and extract the tarballs, then compare their contents
 xz --decompress rustc-*-src.tar.xz
 xz --decompress build/dist/rustc-*-src.tar.xz
-diff rustc-*-src.tar build/dist/rustc-*-src.tar
+
+rm -rf official built
+mkdir official built
+
+tar -xf rustc-*-src.tar -C official
+tar -xf build/dist/rustc-*-src.tar -C built
+
+diff -ru official built
 ```
 
 </details>


### PR DESCRIPTION
Updates the source tarball validation instructions to extract both tarballs and compare their contents instead of comparing the raw tar archives directly.

The direct archive comparison can fail due to archive-level differences even when the extracted contents are effectively equivalent.

This was tested while reproducing rust-lang/rust#155731.

[Rendered](https://github.com/rust-lang/rust-forge/blob/34fd91cc5895b7242ef84bca1b10b985512b9b84/src/infra/other-installation-methods.md)