### PR TITLE
Add global triagebot configuration docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install mdbook
         run: curl -sSL https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar -xz
       - name: Install mdbook-linkcheck2
-        run: cargo install mdbook-linkcheck2@0.11.0 --locked
+        run: cargo install mdbook-linkcheck2@0.12.0 --locked
       - name: Check blacksmith format
         run: cargo fmt --check --manifest-path=blacksmith/Cargo.toml
       - name: Build book

--- a/src/triagebot/concern.md
+++ b/src/triagebot/concern.md
@@ -26,6 +26,9 @@ The concern is then strikethrough and a link to the comment resolving the concer
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization.
+
 This feature is enabled by having a `[concern]` table in `triagebot.toml`:
 
 ```toml

--- a/src/triagebot/index.md
+++ b/src/triagebot/index.md
@@ -35,6 +35,12 @@ For example, the `rust-lang/rust` configuration file is at <https://github.com/r
 When first adding `triagebot.toml` to a new repository, you will need to enable permissions for the bot to operate.
 This can be done by posting a PR to the [`rust-lang/team`](https://github.com/rust-lang/team) database to add `bots = ["rustbot"]` to the repository in the `repos/rust-lang` directory.
 
+### Global configuration
+
+GitHub organizations can have a global configuration that applies to all repositories in the organization. The rust-lang global configuration is located at <https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml>.
+
+The configuration options in the global configuration are the same as in a normal `triagebot.toml` file, except that each configuration entry can include an `excluded-repos = ["rust-lang/foo"]` option that disables that feature for the specified repositories.
+
 ## Common command summary
 
 The following are some common commands you may see on [rust-lang/rust](https://github.com/rust-lang/rust/).

--- a/src/triagebot/issue-assignment.md
+++ b/src/triagebot/issue-assignment.md
@@ -18,6 +18,9 @@ If triagebot is unable to directly assign the user, it will instead assign `@rus
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization.
+
 Issue assignment is enabled on a repository by the existence of the `[assign]` table in `triagebot.toml`:
 
 ```toml

--- a/src/triagebot/merge-conflicts.md
+++ b/src/triagebot/merge-conflicts.md
@@ -12,6 +12,9 @@ Note that it may take a minute or so for the comments to be posted.
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization, except when using bors which has its own notifications.
+
 This feature is enabled on a repository by having a `[merge-conflicts]` table in `triagebot.toml`:
 
 ```toml

--- a/src/triagebot/note.md
+++ b/src/triagebot/note.md
@@ -52,6 +52,9 @@ Triagebot will remove the entry from the summary list.
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization.
+
 This feature is enabled by having a `[note]` table in `triagebot.toml`:
 
 ```toml

--- a/src/triagebot/pr-assignment.md
+++ b/src/triagebot/pr-assignment.md
@@ -44,6 +44,9 @@ If you want to assign the pull request to a different reviewer based on its file
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization.
+
 PR assignment with `r?` is enabled on the repository by having an `[assign]` table in `triagebot.toml`.
 
 If there is an `[assign.owners]` table, then triagebot will automatically select a reviewer based on which files were modified in the PR.

--- a/src/triagebot/range-diff.md
+++ b/src/triagebot/range-diff.md
@@ -5,6 +5,9 @@ This handler posts a comment after such a scenario, which links to triagebot `ra
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization.
+
 This feature is enabled on a repository by having a empty `[range-diff]` table in `triagebot.toml`:
 
 ```toml

--- a/src/triagebot/review-changes-since.md
+++ b/src/triagebot/review-changes-since.md
@@ -8,6 +8,9 @@ When creating a pull request review, the bot will automatically append at the en
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization.
+
 This feature is enabled on a repository by having a `[review-changes-since]` table in `triagebot.toml`:
 
 ```toml

--- a/src/triagebot/transfer.md
+++ b/src/triagebot/transfer.md
@@ -25,6 +25,9 @@ The transfer command is limited to team members of the rust-lang org, as well as
 
 ## Configuration
 
+> [!NOTE]
+> This feature is [enabled by default](https://github.com/rust-lang/triagebot/blob/master/rust-lang.triagebot.toml) in the rust-lang organization.
+
 The source repository must have an empty `transfer` table to enable transfers *from* that repository. Issues can be transferred to any repository in the rust-lang org (that has triagebot enabled).
 
 ```toml


### PR DESCRIPTION
Support for global configuration was added in https://github.com/rust-lang/triagebot/pull/2292.

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/triagebot/index.md)