### PR TITLE
link manifests.txt

### DIFF
--- a/src/infra/channel-layout.md
+++ b/src/infra/channel-layout.md
@@ -9,10 +9,14 @@ A lot of the content herein is derived from
 
 
 Rust releases are deployed onto `static.rust-lang.org` where they are served via
-`https`. There are several parts to a release channel (`stable`, `beta`,
-`nightly`) but they all key off a manifest file and then go from there.
+`https` through our [CDNs](./docs/cdn.md).
+There are several parts to a release channel (`stable`, `beta`, `nightly`)
+but they all key off a manifest file and then go from there.
 
 ## Channel manifests
+
+The [`manifests.txt`](https://static.rust-lang.org/manifests.txt) file lists
+the paths of the channel manifest that have been published so far.
 
 There is a top level directory `/dist/` which contains the channel manifests.
 The manifests are named `channel-rust-[channelname].toml`. Each channel manifest
@@ -129,4 +133,3 @@ Since components and extensions are target-specific in the `pkg` tables, you
 will be able to see that `rust-std` for every target is specified in every
 `rust` target's extensions. This allows for cross-compilation by installation of
 any `rust-std` on any build system.
-

--- a/src/infra/docs/cdn.md
+++ b/src/infra/docs/cdn.md
@@ -3,8 +3,8 @@
 Users of the Rust programming language interact with the infrastructure of the
 project in various different ways. They access the project's website and
 documentation, query the crates index, and download Rust releases and crates.
-These resources are hosted by the Rust project and served through a [Content
-Delivery Network] (CDN).
+These resources are hosted by the Rust project and served through a
+[Content Delivery Network] (CDN).
 
 This document outlines why we use CDNs, for what, and how we have set them up.
 
@@ -63,6 +63,8 @@ pipeline, which is why this distribution has by far the highest traffic volume.
 
 Rust binaries are static and are stored in [Amazon S3], from where they are
 served by the CDNs.
+The supported public layout for release channel manifests
+is documented in the [release channel layout][release-channel-layout].
 
 The distribution for `static.rust-lang.org` has a custom router that runs in a
 [AWS Lambda] function. The router provides a way to list files for a release and
@@ -85,4 +87,5 @@ distribution.
 [aws lambda]: https://aws.amazon.com/lambda/
 [content delivery network]: https://en.wikipedia.org/wiki/Content_delivery_network
 [fastly]: https://www.fastly.com/
+[release-channel-layout]: ../channel-layout.md
 [rust-lang/simpleinfra]: https://github.com/rust-lang/simpleinfra


### PR DESCRIPTION
We got the following feedback from the infra survey:

> Some things just don't seem to be documented anywhere, e.g. where are nightly builds available and how
> are they stored

I think the `channel-layout.md` already documents where nightly builds are available, so I just made a few improvements.

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/infra/channel-layout.md)