### PR TITLE
Small fix to zulip command syntax

### DIFF
--- a/src/triagebot/zulip-commands.md
+++ b/src/triagebot/zulip-commands.md
@@ -43,7 +43,7 @@ Note that the impersonation functionality is intended for inspecting the status 
   - `@**triagebot** ping-goals <threshold> <next-update>`: For use by the goals team to ping goal owners on Zulip to give an update on their goal. Will not ping if there has been a comment in `<threshold>` days. `<next-update>` is a string to say when the next blog update will start.
 - `@**triagebot** docs-update`: Generates a Pull Request ([example](https://github.com/rust-lang/rust/pull/141923)) to update the documentation submodules. See [Documentation Updates](doc-updates.md).
 - `@**triagebot** backport [stable | beta ] [approve | decline ] <PR>` (example: "@triagebot backport beta approve 123456") Will post a comment on GitHub to approve or decline a PR backport (see [Backports](../compiler/backports.md)).
-- `@**triagebot** assign-prio <issue #> [ critical | high | medium | low | <empty>]` will assign a priority label to an issue (see [Prioritization][prio]).
+- `@**triagebot** assign-prio <issue #> [ critical | high | medium | low | none ]` will assign a priority label to an issue (see [Prioritization][prio]). "none" will just remove the `I-prioritize` label.
 
 [prio]: ../compiler/prioritization.md
 


### PR DESCRIPTION
Fixing (my bad) how to invoke the Zulip command `assign-prio`.

thanks

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/triagebot/zulip-commands.md)