### PR TITLE
document how to configure trusted publishing in rust project crates

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -116,6 +116,7 @@
         - [rust-bots server](./infra/docs/rust-bots.md)
         - [rust-lang/rust CI](./infra/docs/rustc-ci.md)
         - [Sentry](./infra/docs/sentry.md)
+        - [Trusted publishing](./infra/docs/trusted-publishing.md)
         - [Internal-facing infrastructure announcements](./infra/docs/internal-announcements.md)
 - [Language](./lang/index.md)
     - [RFC Merge Procedure](./lang/rfc-merge-procedure.md)

--- a/src/infra/docs/trusted-publishing.md
+++ b/src/infra/docs/trusted-publishing.md
@@ -1,0 +1,122 @@
+# Trusted publishing
+
+[Crates.io trusted publishing] lets a GitHub Actions workflow publish a crate
+without storing a long-lived crates.io API token in GitHub Actions secrets.
+
+Trusted publishing is the recommended way to publish Rust Project crates.
+
+This page explains how to configure trusted publishing in Rust Project
+repositories using the [`rust-lang/team`] repository and describes the
+most common publishing patterns.
+
+<div class="warning">
+
+If your repository is not hosted under a Rust GitHub organization, you can't
+configure trusted publishing through the `rust-lang/team` repository. Follow
+the instructions in the [crates.io trusted publishing] documentation instead.
+
+</div>
+
+## 1. Set crate ownership
+
+Make sure the crates you want to manage with trusted publishing are owned by the
+[rust-lang-owner](https://crates.io/users/rust-lang-owner) account.
+If they aren't, invite that account as an owner and ask in the `#t-infra` Zulip
+channel to accept the invitation.
+
+## 2. Configure the team repository
+
+Add a `[[crates-io]]` section to your
+[repository TOML file](https://github.com/rust-lang/team/tree/main/repos), as
+described in the
+[crates.io crate management docs](https://github.com/rust-lang/team/blob/main/docs/toml-schema.md#cratesio-crate-management).
+
+Make sure the environment referenced by `publish-environment` is also defined.
+For example:
+
+```toml
+[environments.publish]
+branches = ["main"]
+
+[[crates-io]]
+publish-environment = "publish"
+...
+```
+
+## 3. Write the GitHub Actions workflow
+
+Every workflow that publishes to crates.io through trusted publishing needs:
+
+- a job with `environment: <publish-environment>`;
+- `permissions: id-token: write` on that job, so GitHub can issue an OIDC token;
+- a workflow file whose name matches `publish-workflow` in `rust-lang/team`.
+
+You can use one of the following approaches to publish your crate with GitHub
+Actions.
+
+### 3a. Publish using cargo
+
+Use this approach if you want to use the [crates-io-auth-action] and run
+`cargo publish` directly in the workflow.
+
+See the "GitHub Actions Setup" section of the
+[crates.io trusted publishing] documentation for more details on how to set up
+the workflow and use the action.
+
+<div class="warning">
+
+The `environment` field of the job is mandatory for Rust Project crates, and it
+needs to match the `publish-environment` field in the `rust-lang/team`
+repository.
+
+For example:
+
+```yaml
+jobs:
+  publish:
+    environment: publish
+    ...
+```
+
+</div>
+
+You can find examples of this approach in Rust Project repositories by using
+[this GitHub search](https://github.com/search?q=org%3Arust-lang+AND+%28path%3A*.yml+OR+path%3A*.yaml%29++rust-lang%2Fcrates-io-auth-action%40&type=code).
+
+```yaml
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+```
+
+Note that you can trigger this workflow from other GitHub events, such as:
+
+* on release:
+  ```yaml
+  on:
+    release:
+      types: [created]
+  ```
+* manually with workflow dispatch:
+  ```yaml
+  on:
+    workflow_dispatch:
+  ```
+
+### 3b. release-plz from the default branch
+
+If you want more automation, instead of running `cargo publish` directly in the
+workflow, check out [release-plz].
+
+You can find examples of `release-plz` in Rust Project repositories by using
+[this GitHub search](https://github.com/search?q=org%3Arust-lang+AND+%28path%3A*.yml+OR+path%3A*.yaml%29++release-plz%2Faction%40&type=code).
+
+[crates.io trusted publishing]: https://crates.io/docs/trusted-publishing
+[release-plz]: https://release-plz.ieni.dev/
+[crates-io-auth-action]: https://github.com/rust-lang/crates-io-auth-action
+[`rust-lang/team`]: https://github.com/rust-lang/team

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -58,6 +58,8 @@ may be approved and merged by `infra-admins`:
 * Changing the [general repository settings](https://github.com/rust-lang/team/blob/master/docs/toml-schema.md#general-repository-settings)
   * This includes granting bots access to the repository.
 * Changing the [repository branch protections](https://github.com/rust-lang/team/blob/master/docs/toml-schema.md#repository-branch-protections)
+* Changing [trusted publishing](./docs/trusted-publishing.md) configuration for
+  crates published through GitHub Actions.
 
 <div class="warning">
 Granting a team write access to `rust-lang/rust` requires approval from both an

--- a/src/policies/crate-ownership.md
+++ b/src/policies/crate-ownership.md
@@ -21,7 +21,7 @@ Rust crates published by the Rust project fall into one of the following categor
 
 Every crate in the organization must be owned by at least one team on crates.io. Teams should use `rust-lang/foo` teams for this. Non-expatriated crates may not have personal accounts as owners; if a crate needs additional owners that are not part of teams; the team should create a project group. Note that this does not forbid non-team (or project group) users from having maintainer access to the repository; it simply forbids them from _publishing_.
 
-Currently it is not possible for a crate to be owned by _only_ a team; the `rust-lang-owner` account (or a similar account to be decided by the infra team) can be used as a stopgap in such cases. We should try to phase this account out as much as possible, in order to make sure it is clear who is responsible for each crate. For crates being auto-published, a `rust-lang/publish-bots` team (or individual bot accounts) can be used to allow bot accounts to publish crates.
+Currently it is not possible for a crate to be owned by _only_ a team; the `rust-lang-owner` account (or a similar account to be decided by the infra team) can be used as a stopgap in such cases. We should try to phase this account out as much as possible, in order to make sure it is clear who is responsible for each crate. For crates being auto-published, use [trusted publishing][trusted-publishing] from GitHub Actions.
 
 Each crate in the organization, and any future crates in the organization, must decide which to which category they belong in according to the above categorization. If you're not sure what the category should be when registering a crate, or do not wish to make a decision just yet, pick "Experimental".
 
@@ -113,3 +113,5 @@ Then, working with the teams, we make these changes to their documentation. We a
 For crates that are in direct use by a lot of the wider community, if we end up categorizing them as anything other than "intentional artifact", there should be an attempt to announce this "change" to the community. While there was no formal commitment made in case of these crates, the vague sense of officialness may have made people believe there was, and we should at least try to rectify this so that people are not continually misled. Whether or not this needs to be done, and how, can be figured out by the individual teams.
 
 A large part of this work can be parallelized; and it does not need to occur all at once.
+
+[trusted-publishing]: ../infra/docs/trusted-publishing.md


### PR DESCRIPTION
r? @ubiratansoares

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/infra/docs/trusted-publishing.md)