### PR TITLE
Clarify RFC merge instructions

### DIFF
--- a/src/lang/rfc-merge-procedure.md
+++ b/src/lang/rfc-merge-procedure.md
@@ -42,14 +42,17 @@ team and asking them to do so.)
 
 ### Step 2: Merge the RFC PR itself
 
-In your local git checkout:
+Once FCP has completed with no concerns unaddressed, in your local git checkout:
 
-- Merge the RFC PR into master in your fork
+- Check out your RFC PR's branch
 - Add a commit that moves the file name from 0000- to its RFC number
 - Edit the new file to include links to the RFC PR and the tracking issue you
   just created in the header
-- Open a PR or push directly to the master branch on rust-lang/rfcs, as
-  appropriate
+- Push to your RFC PR
+
+If you have permissions to merge PRs to rust-lang/rfcs, click the merge button
+on your PR in the GitHub UI. If you don't have permission to merge the PR,
+comment with `r? internal-sites` to have a maintainer merge it on your behalf.
 
 ### Step 3: Leave a comment
 


### PR DESCRIPTION
## What happened

I don't merge RFCs very often, so I went looking for instructions on how to merge them. I happened across this page and started following the instructions-- then found I don't actually have permission to push directly to rust-lang/rfcs master 😅 

The instructions said "Open a PR" [so I did](https://github.com/rust-lang/rfcs/pull/3963), even though that felt strange rather than just pushing them to [my RFC's PR](https://github.com/rust-lang/rfcs/pull/3946), and then [I was informed that what I did was indeed strange](https://github.com/rust-lang/rfcs/pull/3963#issuecomment-4547503654).

## Fix

So I rearranged these instructions to first split based on permissions, then direct those without permissions to add to their existing PR rather than making a new one (assuming the person merging is the PR author, which I believe to be the usual case).

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/lang/rfc-merge-procedure.md)