### PR TITLE
Add documentation for triagebot `[lock]` handler

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -29,6 +29,7 @@
     - [Issue Links](./triagebot/issue-links.md)
     - [Issue Transfer](./triagebot/transfer.md)
     - [Labeling](./triagebot/labeling.md)
+    - [Lock](./triagebot/lock.md)
     - [Major Changes](./triagebot/major-changes.md)
     - [Mentions](./triagebot/mentions.md)
     - [Merge Conflicts](./triagebot/merge-conflicts.md)

--- a/src/triagebot/lock.md
+++ b/src/triagebot/lock.md
@@ -1,0 +1,40 @@
+# Lock
+
+The `lock`/`unlock` commands can be used to lock and unlock a GitHub issue or pull request.
+
+## Usage
+
+### Lock
+
+To lock an issue or pull request, any rust-lang team member may enter the command:
+
+```text
+@rustbot lock
+```
+
+This will immediately lock the issue or PR.
+
+### Unlock
+
+To unlock an issue or pull request, any rust-lang team member may enter the command:
+
+```text
+@rustbot unlock
+```
+
+> [!NOTE]
+> The triagebot Zulip `unlock` command can be used in case it's not possible
+> for the team member to post a command.
+
+## Configuration
+
+This feature is enabled on a repository by having a `[lock]` table in `triagebot.toml`:
+
+```toml
+[lock]
+```
+
+## Implementation
+
+See [`src/handlers/lock.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/src/handlers/lock.rs) and
+[`parser/src/command/lock.rs`](https://github.com/rust-lang/triagebot/blob/HEAD/parser/src/command/lock.rs).

--- a/src/triagebot/zulip-commands.md
+++ b/src/triagebot/zulip-commands.md
@@ -14,6 +14,7 @@ You can send these commands as a direct message to the [triagebot][triagebot-dm]
 - `whoami`: shows the Rust teams that you are a part of
 - `lookup github <zulip-name>`: lookup the GitHub username of a user by their Zulip name
 - `lookup zulip <github-username>`: lookup the Zulip name of a user by their GitHub username
+- `unlock [--org <org>] <repo> <issue-id>`: permits unlocking a given issue or pull-request
 - `user-info <user-name> [--org <org>]`: show basic information about the given GitHub account, including its recent comments and PRs created in the given GitHub organization (`org`)
 - `team-stats <team-name>`: show the review workqueue statistics of all members of the given team
 - `team-stats <team-name> <repo>`: show the review workqueue statistics of all members of the given
@@ -44,6 +45,7 @@ Note that the impersonation functionality is intended for inspecting the status 
 - `@**triagebot** docs-update`: Generates a Pull Request ([example](https://github.com/rust-lang/rust/pull/141923)) to update the documentation submodules. See [Documentation Updates](doc-updates.md).
 - `@**triagebot** backport [stable | beta ] [approve | decline ] <PR>` (example: "@triagebot backport beta approve 123456") Will post a comment on GitHub to approve or decline a PR backport (see [Backports](../compiler/backports.md)).
 - `@**triagebot** assign-prio <issue #> [ critical | high | medium | low | none ]` will assign a priority label to an issue (see [Prioritization][prio]). "none" will just remove the `I-prioritize` label.
+- `@**triagebot** unlock [--org <org>] <repo> <issue-id>`: permits unlocking a given issue or pull-request.
 
 [prio]: ../compiler/prioritization.md
 

--- a/src/triagebot/zulip-commands.md
+++ b/src/triagebot/zulip-commands.md
@@ -14,7 +14,7 @@ You can send these commands as a direct message to the [triagebot][triagebot-dm]
 - `whoami`: shows the Rust teams that you are a part of
 - `lookup github <zulip-name>`: lookup the GitHub username of a user by their Zulip name
 - `lookup zulip <github-username>`: lookup the Zulip name of a user by their GitHub username
-- `unlock [--org <org>] <repo> <issue-id>`: permits unlocking a given issue or pull-request
+- `unlock [--org <org>] <repo> <issue-id>`: permits unlocking a given issue or pull request (default org: rust-lang)
 - `user-info <user-name> [--org <org>]`: show basic information about the given GitHub account, including its recent comments and PRs created in the given GitHub organization (`org`)
 - `team-stats <team-name>`: show the review workqueue statistics of all members of the given team
 - `team-stats <team-name> <repo>`: show the review workqueue statistics of all members of the given
@@ -45,7 +45,7 @@ Note that the impersonation functionality is intended for inspecting the status 
 - `@**triagebot** docs-update`: Generates a Pull Request ([example](https://github.com/rust-lang/rust/pull/141923)) to update the documentation submodules. See [Documentation Updates](doc-updates.md).
 - `@**triagebot** backport [stable | beta ] [approve | decline ] <PR>` (example: "@triagebot backport beta approve 123456") Will post a comment on GitHub to approve or decline a PR backport (see [Backports](../compiler/backports.md)).
 - `@**triagebot** assign-prio <issue #> [ critical | high | medium | low | none ]` will assign a priority label to an issue (see [Prioritization][prio]). "none" will just remove the `I-prioritize` label.
-- `@**triagebot** unlock [--org <org>] <repo> <issue-id>`: permits unlocking a given issue or pull-request.
+- `@**triagebot** unlock [--org <org>] <repo> <issue-id>`: permits unlocking a given issue or pull request (default org: rust-lang).
 
 [prio]: ../compiler/prioritization.md
 


### PR DESCRIPTION
r? @apiraino 

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/triagebot/lock.md)