### PR TITLE
document configured external runners

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -106,6 +106,7 @@
         - [CDN](./infra/docs/cdn.md)
         - [Crater agents](./infra/docs/crater-agents.md)
         - [Dev Desktops](./infra/docs/dev-desktop.md)
+        - [External CI Runners](./infra/docs/external-ci-runners.md)
         - [GitHub App for dev-desktops](./infra/docs/dev-desktop-github-app.md)
         - [Domain names and DNS](./infra/docs/dns.md)
         - [docs.rs](./infra/docs/docs-rs.md)

--- a/src/infra/docs/external-ci-runners.md
+++ b/src/infra/docs/external-ci-runners.md
@@ -1,0 +1,34 @@
+# External CI Runners
+
+The Rust Project mainly runs Continuous Integration (CI) in GitHub Actions.
+When GitHub Actions does not natively support a target, we use
+[self-hosted runners](https://docs.github.com/en/actions/concepts/runners/self-hosted-runners).
+
+## Configured external CI runners
+
+This section lists the external CI runners that are configured to run in the CI of the Rust Project.
+
+Here is an explanation of the fields in the list below:
+
+- `max concurrency`: The available number of runners of this type.
+  This determines the maximum number of GitHub Actions jobs that can run on the runner.
+  The concurrency is shared among repositories. If all runners are busy, GitHub Actions will queue
+  the jobs until a runner is available.
+- `repositories`: The repositories that are enabled to use the runner. To add your repository to the
+  list, please open a PR to this file.
+  Make sure the workflow you want to run the runner on passes [`zizmor`](https://zizmor.sh/).
+- `contact`: The contact information of the person(s) responsible for maintaining the runner.
+  The recommended way to contact them is via Zulip, by opening a new topic in the
+  [#t-infra](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra) channel and mentioning
+  the contact person(s).
+
+### `powerpc64-unknown-linux-musl`
+
+- max concurrency: 4
+- repositories:
+  - [`compiler-builtins`](https://github.com/rust-lang/compiler-builtins)
+  - [`libc`](https://github.com/rust-lang/libc)
+- [example workflow](https://github.com/rust-lang/compiler-builtins/pull/1219)
+- contact:
+  - Zulip: [Aelin](https://rust-lang.zulipchat.com/#user/338253)
+  - Email: `aelin@postmarketos.org` (faster response)


### PR DESCRIPTION
Document the external runners we configured so that people can easily discover them and request them for their repository.

See also https://github.com/rust-lang/infra-team/pull/269 which documents processes for external runners for the infra team.

The setup of these particular runners was discussed in [#t-infra > ppc64 runners for rust-lang repos](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/ppc64.20runners.20for.20rust-lang.20repos/with/600026371)

r? @ubiratansoares 

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/infra/docs/external-ci-runners.md)