### PR TITLE
Update docs for triagebot `[backport]` command

### DIFF
--- a/src/triagebot/zulip-commands.md
+++ b/src/triagebot/zulip-commands.md
@@ -43,7 +43,7 @@ Note that the impersonation functionality is intended for inspecting the status 
 - *Rust Project Goals* commands serve for controlling Rust Project Goal tracking.
   - `@**triagebot** ping-goals <threshold> <next-update>`: For use by the goals team to ping goal owners on Zulip to give an update on their goal. Will not ping if there has been a comment in `<threshold>` days. `<next-update>` is a string to say when the next blog update will start.
 - `@**triagebot** docs-update`: Generates a Pull Request ([example](https://github.com/rust-lang/rust/pull/141923)) to update the documentation submodules. See [Documentation Updates](doc-updates.md).
-- `@**triagebot** backport [stable | beta ] [approve | decline ] <PR>` (example: "@triagebot backport beta approve 123456") Will post a comment on GitHub to approve or decline a PR backport (see [Backports](../compiler/backports.md)).
+- `@**triagebot** backport [approve | decline ] [stable | beta ] <PR>` (example: "@triagebot backport approve beta 123456") Will post a comment on GitHub to approve or decline a PR backport (see [Backports](../compiler/backports.md)).
 - `@**triagebot** assign-prio <issue #> [ critical | high | medium | low | none ]` will assign a priority label to an issue (see [Prioritization][prio]). "none" will just remove the `I-prioritize` label.
 - `@**triagebot** unlock [--org <org>] <repo> <issue-id>`: permits unlocking a given issue or pull request (default org: rust-lang).
 


### PR DESCRIPTION
We are changing the syntax of the Zulip `backport` command to support shorter versions (see https://github.com/rust-lang/triagebot/pull/2423).

The command will now accept:
- `@**triagebot** backport accept beta 123456` (the original one, can be issued everywhere on Zulip)
- `@**triagebot** backport accept beta` (implied PR number, *see Note*)
- `@**triagebot** backport accept` (implied release channel and PR number, *see Note*)

**Note**: the two new shorter versions will parse the Zulip stream title to retrieve the release channel and the PR num. I am trying to be clever so there are not so many safeguards. They will only work if the Zulip stream name is in the form `#123456: beta-nominated` (these streams are auto-generated so we should be relatively safe).

r? @Urgau (after merge of the triagebot patch)

thanks!

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/triagebot/zulip-commands.md)