### PR TITLE
master->main on the title page

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ It's recommended that you put general team information in `src/<TEAM_NAME>/index
 Teams are responsible for merging their own content.
 Please add your team to the `[assign.owners]` section of [`triagebot.toml`] so that the bot will auto-assign someone from the team.
 
-[team-repo]: https://github.com/rust-lang/team/blob/master/repos/rust-lang/rust-forge.toml
+[team-repo]: https://github.com/rust-lang/team/blob/main/repos/rust-lang/rust-forge.toml
 [`src/SUMMARY.md`]: https://github.com/rust-lang/rust-forge/blob/master/src/SUMMARY.md
 [`triagebot.toml`]: https://github.com/rust-lang/rust-forge/blob/master/triagebot.toml
 

--- a/src/compiler/membership.md
+++ b/src/compiler/membership.md
@@ -182,6 +182,6 @@ If you would like to accept, please let me know and I can update the teams repo 
 3. Draft a Inside Rust blog post introducing the new team members. See [previous][p1] [examples][p2]
    for a template.
 
-[team]: https://github.com/rust-lang/team/blob/master/teams/compiler.toml
+[team]: https://github.com/rust-lang/team/blob/main/teams/compiler.toml
 [p1]: https://blog.rust-lang.org/inside-rust/2024/11/12/compiler-team-new-members/
 [p2]: https://blog.rust-lang.org/inside-rust/2024/11/01/compiler-team-reorg/

--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -414,6 +414,6 @@ See [*Adding ecosystem/integration test jobs/components to rust-lang/rust CI*](.
 [rust]: https://github.com/rust-lang/rust
 [compiler_lint_eg]: https://doc.rust-lang.org/rustc/lints/listing/deny-by-default.html#explicit-builtin-cfgs-in-flags
 [ecosystem_testing]: https://rustc-dev-guide.rust-lang.org/tests/ecosystem.html
-[compiler-fcp]: https://github.com/rust-lang/team/blob/master/teams/compiler-fcp.toml
+[compiler-fcp]: https://github.com/rust-lang/team/blob/main/teams/compiler-fcp.toml
 [tier-1-target-policy]: https://doc.rust-lang.org/rustc/target-tier-policy.html#tier-1-target-policy
 [Zulip]: https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler

--- a/src/compiler/third-party-out-of-tree.md
+++ b/src/compiler/third-party-out-of-tree.md
@@ -133,7 +133,7 @@ In summary, the process for establishing an out-of-tree crate is as follows:
        responsible (link to their page in this repository) and the intended level of maintenance and
        stability.
 
-       > This crate is developed and maintained by the [Rust compiler team](https://github.com/rust-lang/compiler-team/tree/master/procedures) for use within
+       > This crate is developed and maintained by the [Rust compiler team](https://rust-lang.org/governance/teams/compiler/) for use within
        > `rustc`, in particular, it is the responsibility of the
        > [`.template`](./working-areas.md) working area. This crate will have regular
        > breaking changes and provides no stability guarantees | is intended to remain stable and have

--- a/src/editions/edition-releases.md
+++ b/src/editions/edition-releases.md
@@ -132,7 +132,7 @@ To perform a crater run, a modified version of `cargo` must be used which will p
 [#87190](https://github.com/rust-lang/rust/pull/87190) contains an example of what this looks like.
 This roughly performs the following steps:
 
-1. Crater runs `cargo check` using the previous master build.
+1. Crater runs `cargo check` using the previous main branch build.
 1. Crater runs `cargo check` using the modified `cargo`. This modified `cargo check` will perform the following steps instead of doing a normal check.
 1. Copies the package to a temp directory (since the source directory is read-only in crater).
 1. Checks if the package's edition is older than the current edition. If so, skip it, since we only want to test migration of the current edition.
@@ -142,7 +142,7 @@ This roughly performs the following steps:
 
 The modified cargo also allows setting the new edition without `cargo-features` being used.
 
-If the final `cargo fix` or `cargo check` steps fail, and the check succeeded on the previous master build, then that signals a regression where the migration failed.
+If the final `cargo fix` or `cargo check` steps fail, and the check succeeded on the previous main branch build, then that signals a regression where the migration failed.
 
 The Edition Project Group is then responsible for analyzing the report, and filing issues for any problems, and following up with teams for getting those fixed.
 

--- a/src/how-to-start-contributing.md
+++ b/src/how-to-start-contributing.md
@@ -71,9 +71,9 @@ have contributor guides and issues that are marked as needing help or being good
 [rustc-repo]: https://github.com/rust-lang/rust
 [rustc-issues]: https://github.com/rust-lang/rust/issues?q=is%3Aopen+is%3Aissue+label%3AE-help-wanted+no%3Aassignee
 [rustc-guide]: https://rustc-dev-guide.rust-lang.org
-[std-repo]: https://github.com/rust-lang/rust/tree/master/library
+[std-repo]: https://github.com/rust-lang/rust/tree/main/library
 [std-guide]: https://std-dev-guide.rust-lang.org
-[rustdoc-repo]: https://github.com/rust-lang/rust/tree/master/src/librustdoc
+[rustdoc-repo]: https://github.com/rust-lang/rust/tree/main/src/librustdoc
 [rustdoc-guide]: https://rustc-dev-guide.rust-lang.org/rustdoc.html
 [cargo-repo]: https://github.com/rust-lang/cargo
 [cargo-issues]: https://github.com/rust-lang/cargo/issues?q=is%3Aopen+is%3Aissue+label%3AS-accepted+no%3Aassignee
@@ -82,7 +82,7 @@ have contributor guides and issues that are marked as needing help or being good
 [clippy-guide]: https://github.com/rust-lang/rust-clippy/blob/master/CONTRIBUTING.md
 [clippy-issues]: https://github.com/rust-lang/rust-clippy/issues?q=is%3Aopen%20is%3Aissue%20no%3Aassignee%20label%3A%22good%20first%20issue%22
 [rustfmt-repo]: https://github.com/rust-lang/rustfmt
-[rustfmt-guide]: https://github.com/rust-lang/rustfmt/blob/master/Contributing.md
+[rustfmt-guide]: https://github.com/rust-lang/rustfmt/blob/main/Contributing.md
 [rustfmt-issues]: https://github.com/rust-lang/rustfmt/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
 [analyzer-repo]: https://github.com/rust-lang/rust-analyzer
 [analyzer-guide]: https://rust-analyzer.github.io/book/contributing

--- a/src/index.md
+++ b/src/index.md
@@ -21,7 +21,7 @@ Avoid changing the "Current Release Versions" without also updating the selector
 in `js/index.js`.
 -->
 
-Channel    | Version | Will be stable on | Will branch from master on |
+Channel    | Version | Will be stable on | Will branch from main on |
 -----------|---------|-------------------|----------------------------|
 Stable     | <span id="stable-version"></span>  | <span id="stable-release-date"></span>  | <span id="stable-branch-date"></span>
 Beta       | <span id="beta-version"></span>    | <span id="beta-release-date"></span>    | <span id="beta-branch-date"></span>

--- a/src/infra/team-maintenance.md
+++ b/src/infra/team-maintenance.md
@@ -55,9 +55,9 @@ Only team accesses should be given to a repository.
 On the other hand, changes to the configuration or automation of repositories
 may be approved and merged by `infra-admins`:
 
-* Changing the [general repository settings](https://github.com/rust-lang/team/blob/master/docs/toml-schema.md#general-repository-settings)
+* Changing the [general repository settings](https://github.com/rust-lang/team/blob/main/docs/toml-schema.md#general-repository-settings)
   * This includes granting bots access to the repository.
-* Changing the [repository rulesets](https://github.com/rust-lang/team/blob/master/docs/toml-schema.md#repository-rulesets)
+* Changing the [repository rulesets](https://github.com/rust-lang/team/blob/main/docs/toml-schema.md#repository-rulesets)
 * Changing [trusted publishing](./docs/trusted-publishing.md) configuration for
   crates published through GitHub Actions.
 
@@ -107,7 +107,7 @@ Remove the team member from any and all places:
 
 [gh-team]: https://github.com/orgs/rust-lang/teams
 [gh-nursery-team]: https://github.com/orgs/rust-lang-nursery/teams
-[team repo]: https://github.com/rust-lang/team/tree/master/teams
+[team repo]: https://github.com/rust-lang/team/tree/main/teams
 [team website]: https://www.rust-lang.org/governance
-[team-repo-admins]: https://github.com/rust-lang/team/blob/master/teams/team-repo-admins.toml
-[infra-admins]: https://github.com/rust-lang/team/blob/master/teams/infra-admins.toml
+[team-repo-admins]: https://github.com/rust-lang/team/blob/main/teams/team-repo-admins.toml
+[infra-admins]: https://github.com/rust-lang/team/blob/main/teams/infra-admins.toml

--- a/src/platforms/blogs.md
+++ b/src/platforms/blogs.md
@@ -95,7 +95,7 @@ The approver should belong to one of the following groups:
 * Rust Foundation project director
 
 These are primarily the members of the
-[inside-rust-reviewers](https://github.com/rust-lang/team/blob/master/teams/inside-rust-reviewers.toml)
+[inside-rust-reviewers](https://github.com/rust-lang/team/blob/main/teams/inside-rust-reviewers.toml)
 marker team[^1]. Note that this applies to *both* the main and inside Rust blogs
 (renaming will happen at some later point).
 

--- a/src/platforms/twitter.md
+++ b/src/platforms/twitter.md
@@ -46,7 +46,7 @@ API keys of the status accounts to automatically tweet about upcoming events on
 crates.io.
 
 Access is limited to a small set of folks in the
-[twitter](https://github.com/rust-lang/team/blob/master/teams/twitter.toml)
+[social-media](https://github.com/rust-lang/team/blob/main/teams/social-media.toml)
 marker team; this isn't automated (changes should ping infra admins for provisioning access).
 
 People with access to 1password should:

--- a/src/release/backporting.md
+++ b/src/release/backporting.md
@@ -7,7 +7,7 @@
 > to ship critical bug-fixes or security patches on channels (like Stable or Beta)
 > that no longer receive every upstream change.
 
-There's a steady trickle of patches (mostly fixes of severe enough bugs) that need to be ported to the beta and stable branch after they're merged into the master branch.
+There's a steady trickle of patches (mostly fixes of severe enough bugs) that need to be ported to the beta and stable branch after they're merged into the main branch.
 Only a few people are even aware of the process, but this is actually something anybody can do.
 
 ## Beta backporting in `rust-lang/rust`

--- a/src/release/release-notes.md
+++ b/src/release/release-notes.md
@@ -158,7 +158,7 @@ notification group via
 @rustbot ping relnotes-interest-group
 ```
 
-[relnotes-interest-group]: https://github.com/rust-lang/team/blob/master/teams/relnotes-interest-group.toml
+[relnotes-interest-group]: https://github.com/rust-lang/team/blob/main/teams/relnotes-interest-group.toml
 
 ## All: Step 6: Incorporate edits from relnotes PR
 

--- a/src/triagebot/github-releases.md
+++ b/src/triagebot/github-releases.md
@@ -20,7 +20,7 @@ To enable automatically creating GitHub Releases, add this to the `triagebot.tom
 format = "rustc"
 project-name = "Rust"
 changelog-path = "RELEASES.md"
-changelog-branch = "master"
+changelog-branch = "main"
 ```
 
 The `format` defines which format the changelog file adheres to, and it's used to properly extract the relevant section from it.

--- a/src/triagebot/pinging.md
+++ b/src/triagebot/pinging.md
@@ -21,7 +21,7 @@ which would cause triagebot to post a comment notifying the members of the `wind
 
 To be pinged, teams have to be created in the [Rust team repository](https://github.com/rust-lang/team).
 Frequently those teams will be marked as `marker-team`, meaning that they do not appear on the website.
-The [WASM team](https://github.com/rust-lang/team/blob/master/teams/wasm.toml#L2) is an example.
+The [WASM team](https://github.com/rust-lang/team/blob/main/teams/wasm.toml#L2) is an example.
 
 Additionally, the team needs to be configured in the repository's `triagebot.toml` file.
 

--- a/src/triagebot/pr-assignment.md
+++ b/src/triagebot/pr-assignment.md
@@ -19,7 +19,7 @@ Manual assignment can be done by posting a comment on the PR with the text:
   For example, for the [rust-lang/rust](https://github.com/rust-lang/rust) repository, see [`triagebot.toml`](https://github.com/rust-lang/rust/blob/HEAD/triagebot.toml) for a list of ad-hoc group names.
 * `r? rust-lang/libs` --- The `rust-lang/` org name prefix is optional.
 * `r? rustdoc` --- Chooses a random person from the rustdoc team.
-  See the [teams database](https://github.com/rust-lang/team/tree/master/teams) for a list of team names.
+  See the [teams database](https://github.com/rust-lang/team/tree/main/teams) for a list of team names.
 * `r? rust-lang/rustdoc` --- The org name prefix is optional.
   It is strongly recommended that you do not use `@`, as that will subscribe and notify the entire team to the PR.
 

--- a/src/triagebot/requesting-prioritization.md
+++ b/src/triagebot/requesting-prioritization.md
@@ -6,7 +6,7 @@ This procedure is usually reserved to *regressions*, the Rust project takes regr
 
 To learn more about this procedure, please visit the [prioritization] documentation.
 
-[gh-regression-tpl]: https://github.com/rust-lang/rust/blob/master/.github/ISSUE_TEMPLATE/regression.md
+[gh-regression-tpl]: https://github.com/rust-lang/rust/blob/main/.github/ISSUE_TEMPLATE/regression.md
 [prioritization]: ../compiler/prioritization.md
 
 ## Usage


### PR DESCRIPTION
r-l/r switched to using "main" a while ago

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/infra/team-maintenance.md)