### PR TITLE
explain trusted publishing environment rules

### DIFF
--- a/src/infra/docs/trusted-publishing.md
+++ b/src/infra/docs/trusted-publishing.md
@@ -43,6 +43,26 @@ publish-environment = "publish"
 ...
 ```
 
+### Environment rules
+
+The environment rules should match the event that triggers the publish
+GitHub Actions workflow.
+
+For example, if the publish is triggered by:
+
+```yaml
+on:
+  push:
+    tags: ["v*"]
+```
+
+then the environment should allow the workflow to run on the same tags pushes:
+
+```toml
+[environments.publish]
+tags = ["v*"]
+```
+
 ## 3. Write the GitHub Actions workflow
 
 Every workflow that publishes to crates.io through trusted publishing needs:


### PR DESCRIPTION
Explain how to prevent errors like https://github.com/rust-lang/team/pull/2524 in the future

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/infra/docs/trusted-publishing.md)