### PR TITLE
Describe approvals for changing tier 1/2 target host tools status

### DIFF
--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -351,6 +351,15 @@ Quick overview for target demotions and removals:
   - Open an RFC describing the motivation for the change and start an FCP to approve, start an FCP.
   - If approved, the change should be accompanied by a blog post announcing the change with a
     notice period of at least one release before the change applies.
+- Changing a tier 1 target's host tools status (without host tools => with host tools, with host
+  tools => without host tools)
+  - **Propose using:** RFC
+  - **Approve using:** FCP
+  - Open an RFC describing the motivation for the change and start an FCP to approve, start an FCP.
+  - If approved, the change should be accompanied by a blog post announcing the change with a
+    notice period of at least one release before the change applies.
+  - For dropping host tools, sometimes the one release grace period may need to be waived out of
+    necessity.
 - Changing target baseline (e.g. minimum Darwin or Windows version bump)
   - **Propose using:** MCP
   - **Approve using:** FCP

--- a/src/compiler/proposals-and-stabilization.md
+++ b/src/compiler/proposals-and-stabilization.md
@@ -340,6 +340,11 @@ Quick overview for target demotions and removals:
   - Open an MCP describing the motivation for the change and start an FCP to approve, start an FCP.
   - If approved, the change should be accompanied by a blog post announcing the change with a
     notice period of at least one release before the change applies.
+- Changing a tier 2 target's host tools status (without host tools => with host tools, with host
+  tools => without host tools)
+  - **Propose using:** MCP
+  - **Approve using:** FCP
+  - Open an MCP describing the motivation for the change and start an FCP to approve, start an FCP.
 - Renaming a target or making a breaking change to a tier 1 target
   - **Propose using:** RFC
   - **Approve using:** FCP


### PR DESCRIPTION
## Summary

It wasn't clear previously, and came up in [#t-compiler/major changes > Drop tier 2 &#96;i686-pc-windows-gnu&#96; host t… compiler-team#1020 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Drop.20tier.202.20.60i686-pc-windows-gnu.60.20host.20t.E2.80.A6.20compiler-team.231020/near/612014830) for https://github.com/rust-lang/compiler-team/issues/1020.

### For Tier 1

Generally adding or removing T1 host tools are very significant, so RFC + FCP feels justified, just like promotions/demotions between T1 <=> T2.

Discussed during [triage meeting](https://rust-lang.zulipchat.com/#narrow/channel/238009-t-compiler.2Fmeetings/topic/.5Bweekly.5D.202026-07-30/near/613667366).

### For Tier 2

The precedents were https://github.com/rust-lang/compiler-team/issues/1020 and https://github.com/rust-lang/compiler-team/issues/961 (tier 2 w/out host tools => tier 2 w/ host tools). I think it's also fine if this was a simple Second, because IMO an FCP feels a *bit* excessive, but yeah.

cc @davidtwco @BoxyUwU 

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/compiler/proposals-and-stabilization.md)