### PR TITLE
Fix name of "`ai-assisted`" label in llm policy

### DIFF
--- a/src/policies/llm-usage.md
+++ b/src/policies/llm-usage.md
@@ -174,7 +174,7 @@ As an exception, PRs written before this policy went into effect are exempt from
 
 ### Procedures
 
-LLM-created PRs must be tagged with a new `ai-assisted` label.
+LLM-created PRs must be tagged with a new `llm-assisted` label.
 All such PRs will be posted to a new (private) Zulip channel, which will be accessible to all members of the `rust-lang` organization.
 The goal of the channel is *not* to act as an additional gatekeeper on LLM-created PRs.
 Instead, it's to collect information about *whether this experiment is working*:


### PR DESCRIPTION
The actual label we created is called `llm-assisted` now.

It's a minimal change, but IMO this point was sufficiently confusing in practice that it's worth fixing sooner rather than later.
This is of course a minor change, following the policy's conditions for modification

> Minor changes, such as typo fixes, only require a normal PR approval.

I've also opened a PR to fix the llm guidance in the dev-guide: rust-lang/rustc-dev-guide#2962

[Rendered](https://github.com/rust-lang/rust-forge/blob/master/src/policies/llm-usage.md)